### PR TITLE
feat(cli): skill marketplace + chat --interactive stdin protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- **Skill marketplace** — new `specsmith skill` subcommand group (`search`, `list`, `install`) backed by a small built-in catalog (`verifier`, `planner`, `diff-reviewer`, `onboarding-coach`, `release-pilot`). `specsmith skill install <slug>` writes the SKILL.md into the project's `.agents/skills/` directory so the local Nexus runtime picks it up. New module `src/specsmith/skills.py` exposes `SkillEntry`, `CATALOG`, `search()`, `get()`, `install()`, `installed_skills()`.
+- **`specsmith chat --interactive` stdin decision protocol** — when launched with `--interactive`, the chat command reads JSONL decision events from stdin so an IDE consumer (e.g. the VS Code extension) can drive the safe-mode approval flow and the inline diff review. The new `--decision-timeout <seconds>` flag bounds the wait. Approved tool calls fall through to the standard tool_call/plan_step/task_complete flow; denied calls emit `task_complete success=False`. The first non-accept `diff_decision` comment is folded into the persisted turn's `reviewer_comment` field so the next harness retry can consume it.
+- **Tests** — `tests/test_skill_marketplace.py` (18 tests) and `tests/test_chat_stdin_protocol.py` (3 tests) cover the new surfaces.
+
 ## [0.5.0] — 2026-04-28
 ### Changed
 - **Agent skill adapter renamed** — the integration adapter that previously generated `.warp/skills/SKILL.md` is now named `agent-skill` and writes to `.agents/skills/SKILL.md`. Existing `scaffold.yml` files that still list `warp` continue to work via a backward-compat alias resolved in `specsmith.integrations.get_adapter`. The legacy `.warp/skills/SKILL.md` path is still patched on `specsmith upgrade` for projects that have not yet rebuilt.

--- a/src/specsmith/cli.py
+++ b/src/specsmith/cli.py
@@ -5437,7 +5437,23 @@ def _read_stdin_decision(expected_type: str, timeout_seconds: float) -> dict[str
     import sys as _sys
 
     line: str | None = None
-    if _sys.platform == "win32":
+
+    # ``select`` only works on real file descriptors. Under test runners
+    # (CliRunner) and other in-memory stdins, ``sys.stdin.fileno()`` raises;
+    # in that case fall back to a direct ``readline()`` which the runner
+    # has already pre-buffered with the supplied ``input``.
+    has_fileno = True
+    try:
+        _sys.stdin.fileno()
+    except (OSError, ValueError, AttributeError):
+        has_fileno = False
+
+    if not has_fileno:
+        try:
+            line = _sys.stdin.readline()
+        except Exception:  # noqa: BLE001 - never let stdin issues kill chat
+            line = None
+    elif _sys.platform == "win32":
         # Windows has no select() on file descriptors; spawn a tiny reader
         # thread and poll a queue.
         import queue as _queue
@@ -5458,7 +5474,10 @@ def _read_stdin_decision(expected_type: str, timeout_seconds: float) -> dict[str
     else:
         import select as _select
 
-        ready, _, _ = _select.select([_sys.stdin], [], [], timeout_seconds)
+        try:
+            ready, _, _ = _select.select([_sys.stdin], [], [], timeout_seconds)
+        except (OSError, ValueError):
+            ready = []
         if ready:
             line = _sys.stdin.readline()
 

--- a/src/specsmith/cli.py
+++ b/src/specsmith/cli.py
@@ -5219,6 +5219,24 @@ main.add_command(index_group)
     default=True,
     help="Emit block-protocol JSONL events (REQ-113). On by default for chat.",
 )
+@click.option(
+    "--interactive",
+    "interactive",
+    is_flag=True,
+    default=False,
+    help=(
+        "Read decision events (tool_decision / diff_decision / comment) from "
+        "stdin. Used by IDE consumers like the VS Code extension to drive "
+        "the safe-mode approval flow and inline diff review."
+    ),
+)
+@click.option(
+    "--decision-timeout",
+    "decision_timeout",
+    type=float,
+    default=120.0,
+    help="Seconds to wait for a stdin decision before falling back to deny.",
+)
 def chat_cmd(
     utterance: str,
     project_dir: str,
@@ -5227,6 +5245,8 @@ def chat_cmd(
     profile: str,
     reviewer_comment: str,
     json_events: bool,
+    interactive: bool,
+    decision_timeout: float,
 ) -> None:
     """Run a single chat turn, streaming JSONL block events to stdout.
 
@@ -5302,35 +5322,44 @@ def chat_cmd(
         matched=len(scope.matched_requirements),
     )
 
-    # Permission gate (REQ-115). In safe mode every tool becomes a request.
+    # Permission gate (REQ-115). In safe mode every tool becomes a request,
+    # and (with --interactive) we then block on stdin for the user's decision.
     if profile == "safe":
         emitter.tool_request(msg_block, "execute_with_governance", {"utterance": utterance})
         emitter.plan_step(plan_block, "s2", "awaiting_approval")
-        emitter.block_complete(plan_block, status="paused")
-        emitter.block_complete(msg_block)
-        emitter.task_complete(
-            success=False,
-            confidence=0.0,
-            summary="Safe mode: tool execution awaiting user approval.",
-            profile=profile,
-        )
-        # Persist turn for memory continuity.
-        append_turn(
-            root,
-            sid,
-            {
-                "role": "user",
-                "utterance": utterance,
-                "profile": profile,
-                "intent": real_intent.value,
-                "status": "awaiting_approval",
-            },
-        )
-        click.echo(_json.dumps({"session_id": sid, "status": "awaiting_approval"}))
-        return
 
-    # Standard / yolo: emit a tool_call event for execute_with_governance and
-    # let downstream consumers route to the real harness if configured.
+        decision = _read_stdin_decision("tool_decision", decision_timeout) if interactive else None
+        if decision and decision.get("decision") == "approve":
+            # User approved — fall through into the standard flow as if the
+            # tool had been pre-authorised.
+            emitter.plan_step(plan_block, "s2", "approved")
+        else:
+            denied_reason = (decision or {}).get("reason", "awaiting_approval")
+            emitter.block_complete(plan_block, status="paused")
+            emitter.block_complete(msg_block)
+            emitter.task_complete(
+                success=False,
+                confidence=0.0,
+                summary=f"Safe mode: {denied_reason}.",
+                profile=profile,
+            )
+            append_turn(
+                root,
+                sid,
+                {
+                    "role": "user",
+                    "utterance": utterance,
+                    "profile": profile,
+                    "intent": real_intent.value,
+                    "status": denied_reason,
+                },
+            )
+            click.echo(_json.dumps({"session_id": sid, "status": denied_reason}))
+            return
+
+    # Standard / yolo / safe-approved: emit a tool_call event for
+    # execute_with_governance and let downstream consumers route to the
+    # real harness if configured.
     emitter.tool_call(msg_block, "execute_with_governance", {"utterance": utterance})
     emitter.plan_step(plan_block, "s2", "complete")
 
@@ -5344,10 +5373,34 @@ def chat_cmd(
     emitter.block_complete(plan_block, status="complete")
     emitter.token(msg_block, summary + "\n")
     emitter.block_complete(msg_block)
+
+    # Optional inline-diff review (REQ-116) when interactive: emit one
+    # representative diff block per matched requirement and read each
+    # diff_decision from stdin. The first non-accept decision becomes the
+    # next retry's reviewer_comment so the harness can adjust.
+    extra_comment = ""
+    if interactive and scope.matched_requirements:
+        for req in scope.matched_requirements[:3]:
+            diff_block = emitter.diff(
+                path=f"docs/{req.req_id}.md",
+                diff=f"--- {req.req_id} (review)\n+++ {req.req_id} (proposed)\n",
+            )
+            decision = _read_stdin_decision("diff_decision", decision_timeout)
+            verdict = (decision or {}).get("decision", "timeout")
+            comment = (decision or {}).get("comment", "")
+            emitter.block_complete(diff_block, status=verdict)
+            if verdict != "accept" and comment:
+                extra_comment = comment
+                break
+
+    final_summary = summary
+    if extra_comment:
+        final_summary += f" reviewer_comment={extra_comment!r}"
+
     emitter.task_complete(
         success=True,
         confidence=0.7,
-        summary=summary,
+        summary=final_summary,
         profile=profile,
         session_id=sid,
         parent_session=parent_session or None,
@@ -5362,11 +5415,64 @@ def chat_cmd(
             "utterance": utterance,
             "profile": profile,
             "intent": real_intent.value,
-            "reviewer_comment": reviewer_comment,
+            "reviewer_comment": reviewer_comment or extra_comment,
             "parent_session": parent_session or None,
             "json_events": json_events,
         },
     )
+
+
+def _read_stdin_decision(expected_type: str, timeout_seconds: float) -> dict[str, Any] | None:
+    """Read a single JSON decision line from stdin with a timeout.
+
+    Used by ``specsmith chat --interactive`` to wait for ``tool_decision``
+    or ``diff_decision`` events emitted by an IDE client. Returns the
+    parsed JSON object or ``None`` if the timeout fires, the line cannot
+    be parsed, or its ``type`` does not match the expected type.
+
+    Cross-platform: uses ``select`` on POSIX and a polling reader thread
+    on Windows so the flow stays non-blocking on either OS.
+    """
+    import json as _json
+    import sys as _sys
+
+    line: str | None = None
+    if _sys.platform == "win32":
+        # Windows has no select() on file descriptors; spawn a tiny reader
+        # thread and poll a queue.
+        import queue as _queue
+        import threading as _threading
+
+        q: _queue.Queue[str] = _queue.Queue()
+
+        def _reader() -> None:
+            data = _sys.stdin.readline()
+            q.put(data)
+
+        t = _threading.Thread(target=_reader, daemon=True)
+        t.start()
+        try:
+            line = q.get(timeout=timeout_seconds)
+        except _queue.Empty:
+            line = None
+    else:
+        import select as _select
+
+        ready, _, _ = _select.select([_sys.stdin], [], [], timeout_seconds)
+        if ready:
+            line = _sys.stdin.readline()
+
+    if not line or not line.strip():
+        return None
+    try:
+        payload = _json.loads(line.strip())
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("type") != expected_type:
+        return None
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -5939,6 +6045,116 @@ def drive_pull(kind: str, project_dir: str, force: bool) -> None:
 
 
 main.add_command(drive_group)
+
+
+# ---------------------------------------------------------------------------
+# Skill marketplace — search / list / install community skills
+# ---------------------------------------------------------------------------
+
+
+@main.group(name="skill")
+def skill_group() -> None:
+    """Discover, list, and install community SKILL.md files.
+
+    specsmith ships a small built-in catalog of reusable skills. Each entry
+    is a short Markdown file describing a workflow the agent should follow
+    (verifier, planner, diff-reviewer, onboarding-coach, release-pilot).
+    ``specsmith skill install <slug>`` copies the SKILL.md into
+    ``.agents/skills/`` so the local Nexus runtime picks it up alongside any
+    project-specific skills.
+    """
+
+
+@skill_group.command(name="search")
+@click.argument("query", required=False, default="")
+@click.option("--json", "as_json", is_flag=True, default=False)
+def skill_search(query: str, as_json: bool) -> None:
+    """Search the catalog for skills matching QUERY (case-insensitive)."""
+    import json as _json
+
+    from specsmith import skills as _skills
+
+    matches = _skills.search(query)
+    if as_json:
+        click.echo(
+            _json.dumps(
+                [
+                    {
+                        "slug": m.slug,
+                        "name": m.name,
+                        "description": m.description,
+                        "tags": list(m.tags),
+                    }
+                    for m in matches
+                ],
+                indent=2,
+            )
+        )
+        return
+    if not matches:
+        console.print("[dim]No matching skills.[/dim]")
+        return
+    for entry in matches:
+        console.print(f"[bold]{entry.slug}[/bold] \u2014 {entry.name}")
+        console.print(f"  {entry.description}")
+        if entry.tags:
+            console.print(f"  [dim]tags: {', '.join(entry.tags)}[/dim]")
+
+
+@skill_group.command(name="list")
+@click.option("--project-dir", type=click.Path(exists=True), default=".")
+@click.option("--json", "as_json", is_flag=True, default=False)
+def skill_list(project_dir: str, as_json: bool) -> None:
+    """Show installed skills (under .agents/skills/) and the catalog."""
+    import json as _json
+
+    from specsmith import skills as _skills
+
+    root = Path(project_dir).resolve()
+    installed = [p.name for p in _skills.installed_skills(root)]
+    catalog = [
+        {"slug": entry.slug, "name": entry.name, "installed": f"{entry.slug}.md" in installed}
+        for entry in _skills.CATALOG
+    ]
+    if as_json:
+        click.echo(_json.dumps({"installed": installed, "catalog": catalog}, indent=2))
+        return
+    console.print(f"[bold]Installed skills[/bold] ({len(installed)})")
+    for name in installed:
+        console.print(f"  [green]\u2713[/green] {name}")
+    if not installed:
+        console.print("  [dim](none)[/dim]")
+    console.print()
+    console.print("[bold]Catalog[/bold]")
+    for entry in catalog:
+        marker = "[green]\u2713[/green]" if entry["installed"] else "[dim]\u2014[/dim]"
+        console.print(f"  {marker} {entry['slug']:20s} {entry['name']}")
+
+
+@skill_group.command(name="install")
+@click.argument("slug")
+@click.option("--project-dir", type=click.Path(exists=True), default=".")
+@click.option("--force", is_flag=True, default=False, help="Overwrite an existing file.")
+def skill_install(slug: str, project_dir: str, force: bool) -> None:
+    """Install SLUG into the project's .agents/skills/ directory."""
+    from specsmith import skills as _skills
+
+    root = Path(project_dir).resolve()
+    try:
+        target = _skills.install(slug, root, force=force)
+    except KeyError:
+        console.print(f"[red]Unknown skill: {slug}[/red]")
+        console.print("  Run [bold]specsmith skill search[/bold] to browse the catalog.")
+        raise SystemExit(1) from None
+    except FileExistsError as exc:
+        console.print(f"[yellow]{exc}[/yellow]")
+        raise SystemExit(2) from None
+    console.print(
+        f"[green]\u2713[/green] Installed [bold]{slug}[/bold] at {target.relative_to(root)}"
+    )
+
+
+main.add_command(skill_group)
 
 
 # ---------------------------------------------------------------------------

--- a/src/specsmith/skills.py
+++ b/src/specsmith/skills.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+"""Skill marketplace — discover and install reusable agent skill files.
+
+specsmith ships a small built-in catalog of community skills (Markdown
+SKILL.md files) that any user can drop into their project's
+``.agents/skills/`` directory. The catalog is keyed by slug; each entry
+has a name, description, tags, and the SKILL.md body. Future versions
+may federate to a remote registry behind a ``--registry-url`` flag, but
+the built-in catalog is sufficient for the 1.0-class user experience:
+``specsmith skill search testing`` lists matching skills,
+``specsmith skill install verifier`` copies the SKILL.md into the
+project, and ``specsmith skill list`` shows what's already installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class SkillEntry:
+    """A single skill catalog entry."""
+
+    slug: str
+    name: str
+    description: str
+    tags: list[str] = field(default_factory=list)
+    body: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Built-in catalog
+# ---------------------------------------------------------------------------
+
+CATALOG: list[SkillEntry] = [
+    SkillEntry(
+        slug="verifier",
+        name="Verifier — five-gate verification",
+        description=(
+            "Runs the standard five-gate verification loop: ruff, mypy, pytest, "
+            "pip-audit, and the project's own audit/validate. Halts with a clear "
+            "report at the first failing gate."
+        ),
+        tags=["verification", "ci", "python"],
+        body=(
+            "# Verifier Skill\n\n"
+            "## When to use\n"
+            "Run this skill before committing any change.\n\n"
+            "## Gates (in order)\n"
+            "1. `ruff check .` — lint clean.\n"
+            "2. `ruff format --check src tests` — format clean.\n"
+            "3. `mypy src/` — type-check clean.\n"
+            "4. `pytest -q` — tests pass.\n"
+            "5. `specsmith audit && specsmith validate` — governance clean.\n\n"
+            "Halt at the first failing gate and surface its output verbatim.\n"
+        ),
+    ),
+    SkillEntry(
+        slug="planner",
+        name="Planner — propose-then-execute",
+        description=(
+            "Forces the agent to emit a Plan block before any tool call. Each "
+            "plan step is recorded with explicit success criteria so the user "
+            "can review the approach before any code changes."
+        ),
+        tags=["planning", "governance"],
+        body=(
+            "# Planner Skill\n\n"
+            "## Protocol\n"
+            "1. Emit a Plan block listing each intended step with a success "
+            "criterion.\n"
+            "2. Wait for user confirmation when the profile is `safe`.\n"
+            "3. Execute steps one at a time, updating plan_step status as each "
+            "completes or fails.\n"
+            "4. Never run tool calls outside the plan.\n"
+        ),
+    ),
+    SkillEntry(
+        slug="diff-reviewer",
+        name="Diff Reviewer — surface changes for approval",
+        description=(
+            "After every change set, emit a `diff` block per modified file and "
+            "wait for an Accept / Reject decision before committing. Comments "
+            "are fed into the next retry as additional context."
+        ),
+        tags=["review", "diff", "governance"],
+        body=(
+            "# Diff Reviewer Skill\n\n"
+            "## When to use\n"
+            "Any task that modifies files.\n\n"
+            "## Protocol\n"
+            "1. Emit one `diff` block per file in `Files changed`.\n"
+            "2. Wait for `diff_decision` events on stdin (accept / reject / "
+            "comment).\n"
+            "3. If any diff is rejected, fold the comment into the next harness "
+            "retry.\n"
+            "4. Only commit once every diff has been accepted.\n"
+        ),
+    ),
+    SkillEntry(
+        slug="onboarding-coach",
+        name="Onboarding Coach — guided first session",
+        description=(
+            "Walks a brand-new user through a project: scaffold check, "
+            "REQUIREMENTS.md tour, AGENTS.md tour, suggested next preflight "
+            "utterance. Pairs with `specsmith doctor --onboarding`."
+        ),
+        tags=["onboarding", "documentation"],
+        body=(
+            "# Onboarding Coach Skill\n\n"
+            "## Sequence\n"
+            "1. Run `specsmith doctor --onboarding` and surface any failing "
+            "step.\n"
+            "2. Read AGENTS.md and summarise the project's hard rules in 5 "
+            "bullets.\n"
+            "3. List the top 5 P1 requirements from REQUIREMENTS.md.\n"
+            "4. Suggest one preflight utterance the user can run next.\n"
+        ),
+    ),
+    SkillEntry(
+        slug="release-pilot",
+        name="Release Pilot — gitflow release cut",
+        description=(
+            "Drives a full gitflow release: develop -> main fast-forward, "
+            "version bump, CHANGELOG entry, tag, PyPI publish, GitHub release. "
+            "Refuses to run if CI is not green."
+        ),
+        tags=["release", "vcs", "automation"],
+        body=(
+            "# Release Pilot Skill\n\n"
+            "## Preconditions\n"
+            "- `gh pr list --state open` returns 0 open PRs.\n"
+            "- All CI checks on develop are SUCCESS.\n"
+            "- CHANGELOG.md has the new version entry already drafted.\n\n"
+            "## Sequence\n"
+            "1. Bump `pyproject.toml` version.\n"
+            "2. Commit and push to develop.\n"
+            "3. Fast-forward main from develop.\n"
+            "4. Create annotated tag.\n"
+            "5. Push tags. Release workflow handles PyPI + GitHub Release.\n"
+        ),
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def search(query: str) -> list[SkillEntry]:
+    """Case-insensitive substring search across slug, name, description, tags."""
+    needle = query.strip().lower()
+    if not needle:
+        return list(CATALOG)
+    matches: list[SkillEntry] = []
+    for entry in CATALOG:
+        haystack = " ".join(
+            [entry.slug, entry.name, entry.description, " ".join(entry.tags)]
+        ).lower()
+        if needle in haystack:
+            matches.append(entry)
+    return matches
+
+
+def get(slug: str) -> SkillEntry | None:
+    """Return the catalog entry for ``slug`` or ``None``."""
+    for entry in CATALOG:
+        if entry.slug == slug:
+            return entry
+    return None
+
+
+def installed_skills(project_dir: Path) -> list[Path]:
+    """Return SKILL.md files installed under ``.agents/skills/``."""
+    base = project_dir / ".agents" / "skills"
+    if not base.is_dir():
+        return []
+    return sorted(p for p in base.iterdir() if p.is_file() and p.suffix == ".md")
+
+
+def install(slug: str, project_dir: Path, *, force: bool = False) -> Path:
+    """Copy the catalog skill into ``project_dir/.agents/skills/<slug>.md``.
+
+    Raises ``FileExistsError`` if the file is already present and ``force``
+    is ``False``. Raises ``KeyError`` if the slug is unknown.
+    """
+    entry = get(slug)
+    if entry is None:
+        raise KeyError(f"Unknown skill: {slug}")
+    base = project_dir / ".agents" / "skills"
+    base.mkdir(parents=True, exist_ok=True)
+    target = base / f"{slug}.md"
+    if target.exists() and not force:
+        raise FileExistsError(f"Already installed: {target}. Pass --force to overwrite.")
+    target.write_text(entry.body, encoding="utf-8")
+    return target

--- a/tests/test_chat_stdin_protocol.py
+++ b/tests/test_chat_stdin_protocol.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+"""Tests for `specsmith chat --interactive` stdin decision protocol.
+
+The interactive flow lets an IDE consumer (e.g. the VS Code extension)
+drive the safe-mode approval and inline diff review by writing JSON
+decision lines to the CLI's stdin.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from specsmith.cli import main
+
+
+def test_chat_safe_mode_denies_when_no_stdin(tmp_path: Path) -> None:
+    """Without --interactive, safe profile emits tool_request and stops."""
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        ["chat", "add hello world", "--project-dir", str(tmp_path), "--profile", "safe"],
+    )
+    assert res.exit_code == 0, res.output
+    events = [json.loads(line) for line in res.output.strip().splitlines() if line.startswith("{")]
+    assert "tool_request" in [e.get("type") for e in events]
+
+
+def test_chat_interactive_safe_mode_approve(tmp_path: Path) -> None:
+    """With --interactive and an approve decision on stdin, chat continues."""
+    runner = CliRunner()
+    decision = json.dumps({"type": "tool_decision", "decision": "approve"}) + "\n"
+    res = runner.invoke(
+        main,
+        [
+            "chat",
+            "add hello world",
+            "--project-dir",
+            str(tmp_path),
+            "--profile",
+            "safe",
+            "--interactive",
+            "--decision-timeout",
+            "5",
+        ],
+        input=decision,
+    )
+    assert res.exit_code == 0, res.output
+    # When approved, we should see a tool_call event after the tool_request.
+    types = [
+        json.loads(line).get("type")
+        for line in res.output.strip().splitlines()
+        if line.startswith("{")
+    ]
+    assert "tool_request" in types
+    assert "tool_call" in types
+
+
+def test_chat_interactive_safe_mode_deny(tmp_path: Path) -> None:
+    """With --interactive and a deny decision, chat exits with task_complete success=False."""
+    runner = CliRunner()
+    decision = json.dumps({"type": "tool_decision", "decision": "deny", "reason": "not_now"}) + "\n"
+    res = runner.invoke(
+        main,
+        [
+            "chat",
+            "add hello world",
+            "--project-dir",
+            str(tmp_path),
+            "--profile",
+            "safe",
+            "--interactive",
+            "--decision-timeout",
+            "5",
+        ],
+        input=decision,
+    )
+    assert res.exit_code == 0, res.output
+    parsed = [
+        json.loads(line)
+        for line in res.output.strip().splitlines()
+        if line.startswith("{") and '"type"' in line
+    ]
+    completes = [e for e in parsed if e.get("type") == "task_complete"]
+    assert completes
+    assert completes[-1].get("success") is False

--- a/tests/test_skill_marketplace.py
+++ b/tests/test_skill_marketplace.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+"""Tests for the `specsmith skill` subcommand group and skills module.
+
+The skill marketplace exposes a tiny built-in catalog (verifier, planner,
+diff-reviewer, onboarding-coach, release-pilot) that can be searched,
+listed, and installed into a project's ``.agents/skills/`` directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from specsmith import skills
+from specsmith.cli import main
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (search / get / install)
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_has_expected_slugs() -> None:
+    slugs = {entry.slug for entry in skills.CATALOG}
+    assert {"verifier", "planner", "diff-reviewer", "onboarding-coach", "release-pilot"} <= slugs
+
+
+def test_search_empty_query_returns_full_catalog() -> None:
+    matches = skills.search("")
+    assert len(matches) == len(skills.CATALOG)
+
+
+def test_search_matches_by_tag() -> None:
+    matches = skills.search("release")
+    assert any(m.slug == "release-pilot" for m in matches)
+
+
+def test_search_is_case_insensitive() -> None:
+    matches = skills.search("VERIFIER")
+    assert any(m.slug == "verifier" for m in matches)
+
+
+def test_get_returns_entry_for_known_slug() -> None:
+    entry = skills.get("verifier")
+    assert entry is not None
+    assert entry.name.startswith("Verifier")
+
+
+def test_get_returns_none_for_unknown_slug() -> None:
+    assert skills.get("does-not-exist") is None
+
+
+def test_install_writes_skill_md(tmp_path: Path) -> None:
+    target = skills.install("verifier", tmp_path)
+    assert target.is_file()
+    assert target.parent == tmp_path / ".agents" / "skills"
+    assert target.read_text(encoding="utf-8").startswith("# Verifier Skill")
+
+
+def test_install_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    skills.install("verifier", tmp_path)
+    try:
+        skills.install("verifier", tmp_path)
+    except FileExistsError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected FileExistsError")
+
+
+def test_install_force_overwrites(tmp_path: Path) -> None:
+    target = skills.install("verifier", tmp_path)
+    target.write_text("STALE", encoding="utf-8")
+    rewritten = skills.install("verifier", tmp_path, force=True)
+    assert rewritten.read_text(encoding="utf-8").startswith("# Verifier Skill")
+
+
+def test_install_unknown_slug_raises_keyerror(tmp_path: Path) -> None:
+    try:
+        skills.install("does-not-exist", tmp_path)
+    except KeyError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected KeyError")
+
+
+def test_installed_skills_lists_md_files(tmp_path: Path) -> None:
+    skills.install("verifier", tmp_path)
+    skills.install("planner", tmp_path)
+    listed = skills.installed_skills(tmp_path)
+    names = sorted(p.name for p in listed)
+    assert names == ["planner.md", "verifier.md"]
+
+
+# ---------------------------------------------------------------------------
+# CLI: specsmith skill search / list / install
+# ---------------------------------------------------------------------------
+
+
+def test_cli_skill_search_text(tmp_path: Path) -> None:
+    runner = CliRunner()
+    res = runner.invoke(main, ["skill", "search", "verifier"])
+    assert res.exit_code == 0, res.output
+    assert "verifier" in res.output
+
+
+def test_cli_skill_search_json(tmp_path: Path) -> None:
+    runner = CliRunner()
+    res = runner.invoke(main, ["skill", "search", "release", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert any(item["slug"] == "release-pilot" for item in payload)
+
+
+def test_cli_skill_list_json_shows_catalog(tmp_path: Path) -> None:
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        ["skill", "list", "--json", "--project-dir", str(tmp_path)],
+    )
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["installed"] == []
+    slugs = {entry["slug"] for entry in payload["catalog"]}
+    assert "verifier" in slugs
+
+
+def test_cli_skill_install_then_list(tmp_path: Path) -> None:
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        ["skill", "install", "verifier", "--project-dir", str(tmp_path)],
+    )
+    assert res.exit_code == 0, res.output
+    assert (tmp_path / ".agents" / "skills" / "verifier.md").is_file()
+
+    res2 = runner.invoke(
+        main,
+        ["skill", "list", "--json", "--project-dir", str(tmp_path)],
+    )
+    payload = json.loads(res2.output)
+    assert "verifier.md" in payload["installed"]
+    verifier_entry = next(e for e in payload["catalog"] if e["slug"] == "verifier")
+    assert verifier_entry["installed"] is True
+
+
+def test_cli_skill_install_unknown_exits_1(tmp_path: Path) -> None:
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        ["skill", "install", "does-not-exist", "--project-dir", str(tmp_path)],
+    )
+    assert res.exit_code == 1
+    assert "Unknown skill" in res.output
+
+
+def test_cli_skill_install_existing_exits_2(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        ["skill", "install", "verifier", "--project-dir", str(tmp_path)],
+    )
+    res = runner.invoke(
+        main,
+        ["skill", "install", "verifier", "--project-dir", str(tmp_path)],
+    )
+    assert res.exit_code == 2
+    assert "Already installed" in res.output
+
+
+def test_cli_skill_install_force_overwrites(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        ["skill", "install", "verifier", "--project-dir", str(tmp_path)],
+    )
+    target = tmp_path / ".agents" / "skills" / "verifier.md"
+    target.write_text("STALE", encoding="utf-8")
+    res = runner.invoke(
+        main,
+        ["skill", "install", "verifier", "--force", "--project-dir", str(tmp_path)],
+    )
+    assert res.exit_code == 0, res.output
+    assert target.read_text(encoding="utf-8").startswith("# Verifier Skill")


### PR DESCRIPTION
## Summary
Adds two Warp-parity surfaces to the specsmith CLI so the upcoming specsmith-vscode interactive chat panel has a real backend to talk to:

1. **Skill marketplace** — `specsmith skill search/list/install` over a 5-entry built-in catalog (`verifier` / `planner` / `diff-reviewer` / `onboarding-coach` / `release-pilot`). `install` writes the SKILL.md into `.agents/skills/` so the local Nexus runtime picks it up.
2. **Chat stdin decision protocol** — `specsmith chat --interactive [--decision-timeout SECONDS]` blocks on stdin reading a single JSON `tool_decision` line in safe-mode (approve → falls through to `tool_call`; deny → `task_complete success=False`). After verification, when interactive, emits up to 3 `diff` blocks per matched requirement and reads `diff_decision` events; the first non-accept `comment` is folded into the persisted turn's `reviewer_comment` for the next harness retry.

## Files
- `src/specsmith/skills.py` (new) — `SkillEntry`, `CATALOG`, `search()`, `get()`, `install()`, `installed_skills()`.
- `src/specsmith/cli.py` — new `skill` Click group; `chat_cmd` extended with `--interactive` / `--decision-timeout` and a cross-platform `_read_stdin_decision()` helper (`select` on POSIX, queue+thread on Windows).
- `tests/test_skill_marketplace.py` — 18 new tests.
- `tests/test_chat_stdin_protocol.py` — 3 new tests.
- `CHANGELOG.md` — Unreleased entry.

## Validation
- `ruff check .` + `ruff format --check src tests` — clean.
- `mypy src/specsmith/` — clean (76 source files).
- `pytest -q` — **304 passed, 1 skipped**.

## Why now
This is the CLI half of the four previously-deferred Warp-parity items:
- voice input → handled in specsmith-vscode (next PR).
- marketplace skill discovery → **this PR**.
- interactive Accept/Reject/Comment buttons → **this PR** (CLI side; webview wiring next).
- separate sub-session UI pane → handled in specsmith-vscode (next PR).

The specsmith-vscode PR depends on this stdin protocol shipping first.

## Artifacts
- Conversation: https://app.warp.dev/conversation/6f8aa790-049b-4ddf-9c52-4840728faee5
- Roadmap: https://app.warp.dev/drive/notebook/WT8Mspj5xajKDIBDRTkerU

Co-Authored-By: Oz <oz-agent@warp.dev>