### PR TITLE
chore(changelog): consolidate Unreleased entries into [0.5.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+
+## [0.5.0] — 2026-04-28
+
+_All work between the original 0.5.0 release and the chat-system
+wrap-up is consolidated under this single 0.5.0 entry. No published
+`vX.Y.Z.devN` PyPI artifacts were rolled back; only the changelog
+heading was collapsed back to 0.5.0 (the `pyproject.toml` version was
+already 0.5.0)._
+
+### Added — chat orchestrator + skill marketplace + diff_decision tests
 - **Skill marketplace** — new `specsmith skill` subcommand group (`search`, `list`, `install`) backed by a small built-in catalog (`verifier`, `planner`, `diff-reviewer`, `onboarding-coach`, `release-pilot`). `specsmith skill install <slug>` writes the SKILL.md into the project's `.agents/skills/` directory so the local Nexus runtime picks it up. New module `src/specsmith/skills.py` exposes `SkillEntry`, `CATALOG`, `search()`, `get()`, `install()`, `installed_skills()`.
 - **`specsmith chat --interactive` stdin decision protocol** — when launched with `--interactive`, the chat command reads JSONL decision events from stdin so an IDE consumer (e.g. the VS Code extension) can drive the safe-mode approval flow and the inline diff review. The new `--decision-timeout <seconds>` flag bounds the wait. Approved tool calls fall through to the standard tool_call/plan_step/task_complete flow; denied calls emit `task_complete success=False`. The first non-accept `diff_decision` comment is folded into the persisted turn's `reviewer_comment` field so the next harness retry can consume it.
 - **Real chat orchestrator** — new `src/specsmith/agent/chat_runner.py` powers `specsmith chat` with a streaming LLM turn. Provider preference is local-first: Ollama (default `http://127.0.0.1:11434`, model `qwen2.5:7b`), then the `anthropic`, `openai`, and `google-genai` SDKs gated on the corresponding API-key env vars. Tokens are streamed to the existing `EventEmitter` as `token` events, and the model's `Plan: / Files changed: / Test results:` sections feed `specsmith.agent.verifier.score()` so `task_complete.confidence` and the `success` flag now reflect a real verdict. Any provider error or missing SDK transparently falls back to the deterministic stub; set `SPECSMITH_DISABLE_REAL_CHAT=1` to force the stub explicitly (used by the test suite).
@@ -14,16 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Hermetic test fixture** — a new autouse fixture in `tests/conftest.py` sets `SPECSMITH_NO_AUTO_UPDATE=1` and `SPECSMITH_PYPI_CHECKED=1` so the project-update prompt and the PyPI version check do not consume stdin or hit the network during tests. This made the existing `test_chat_stdin_protocol.py` tests pass deterministically when run individually, not just as part of the full suite.
 - **Documentation** — `docs/site/commands.md` now documents `specsmith chat` (block protocol, stdin decision protocol, real-LLM provider order, fallback behaviour) and `specsmith skill` (`list`, `search`, `install`).
 - **Tests** — `tests/test_skill_marketplace.py` (18 tests), `tests/test_chat_stdin_protocol.py` (3 tests), and `tests/test_chat_diff_decision.py` (3 tests) cover the new surfaces.
-### Fixed
-- **`specsmith chat` diff block kwarg** — the inline diff review path called `EventEmitter.diff(path=..., diff=...)` but the helper takes `body=`. The kwarg mismatch was latent because no existing test created a `REQUIREMENTS.md` that triggered scope-matched diff blocks. Fixed in `src/specsmith/cli.py` and exercised by `tests/test_chat_diff_decision.py`.
 
-## [0.5.0] — 2026-04-28
 ### Changed
 - **Agent skill adapter renamed** — the integration adapter that previously generated `.warp/skills/SKILL.md` is now named `agent-skill` and writes to `.agents/skills/SKILL.md`. Existing `scaffold.yml` files that still list `warp` continue to work via a backward-compat alias resolved in `specsmith.integrations.get_adapter`. The legacy `.warp/skills/SKILL.md` path is still patched on `specsmith upgrade` for projects that have not yet rebuilt.
 - **Customer-facing docs** — Read the Docs pages (`agent-integrations.md`, `getting-started.md`, `configuration.md`, `commands.md`, `agent-client.md`) and `TESTS.md` no longer reference any specific terminal-AI vendor by name. The `agent-skill` adapter is described as a generic SKILL.md integration for terminal-native AI agents.
 - **REQ-079 / ARCHITECTURE.md cleanup boundary text** — protected-paths description generalised to “third-party agent integration directories (e.g. `.agents/`)”. Defensive code in `agent/cleanup.py` continues to protect both `.agents/` and `.warp/` for users who already have either directory in their project.
-- **`pyproject.toml`** version bumped to `0.5.0`. `Development Status :: 4 - Beta` classifier preserved (1.0.0 stays deferred per the pre-1.0 stance).
+- **`pyproject.toml`** version held at `0.5.0`. `Development Status :: 4 - Beta` classifier preserved (1.0.0 stays deferred per the pre-1.0 stance).
 - **`scaffold.yml`** integration list switched to the new `agent-skill` adapter name in this repo's own scaffold.
+
+### Fixed
+- **`specsmith chat` diff block kwarg** — the inline diff review path called `EventEmitter.diff(path=..., diff=...)` but the helper takes `body=`. The kwarg mismatch was latent because no existing test created a `REQUIREMENTS.md` that triggered scope-matched diff blocks. Fixed in `src/specsmith/cli.py` and exercised by `tests/test_chat_diff_decision.py`.
+
 ### Internal
 - New module `src/specsmith/integrations/agent_skill.py` (`AgentSkillAdapter`) replaces `src/specsmith/integrations/warp.py` (file removed). `LEGACY_ALIASES = {"warp": "agent-skill"}` in `src/specsmith/integrations/__init__.py` keeps existing configs working without manual migration.
 - `tests/test_integrations.py` covers the new canonical name, the legacy alias, and the new `.agents/skills/` output path.


### PR DESCRIPTION
## Summary

Consolidates the `[Unreleased]` CHANGELOG entries (chat orchestrator, skill marketplace, `--interactive` stdin protocol, diff_decision tests, hermetic test fixture, docs) back into the existing `[0.5.0]` section. **No version bump.** `pyproject.toml` was already pinned at `0.5.0`; only the changelog heading collapsed.

## Why

Per repository policy, all post-0.5.0 work consolidates under 0.5.0 until an explicit version bump is requested.

## Out of scope (intentionally not changed)

- The `0.5.0.devN` PyPI artifacts already published from `develop` are **not** rolled back. The CHANGELOG body explicitly documents this.
- Code, tests, and docs from the chat orchestrator + skill marketplace work all stay in place — this is purely a changelog consolidation.

## Verification

- `git --no-pager diff develop -- CHANGELOG.md` shows only the `[Unreleased]` block being merged into the existing `[0.5.0]` section.
- `pyproject.toml` `version = "0.5.0"` is unchanged.

Co-Authored-By: Oz <oz-agent@warp.dev>
