### PR TITLE
release: bump to 0.6.0 (chat orchestrator + skill marketplace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] — 2026-04-28
+## [0.6.0] — 2026-04-28
 
-_All work between the original 0.5.0 release and the chat-system
-wrap-up is consolidated under this single 0.5.0 entry. No published
-`vX.Y.Z.devN` PyPI artifacts were rolled back; only the changelog
-heading was collapsed back to 0.5.0 (the `pyproject.toml` version was
-already 0.5.0)._
-
-### Added — chat orchestrator + skill marketplace + diff_decision tests
+### Added
 - **Skill marketplace** — new `specsmith skill` subcommand group (`search`, `list`, `install`) backed by a small built-in catalog (`verifier`, `planner`, `diff-reviewer`, `onboarding-coach`, `release-pilot`). `specsmith skill install <slug>` writes the SKILL.md into the project's `.agents/skills/` directory so the local Nexus runtime picks it up. New module `src/specsmith/skills.py` exposes `SkillEntry`, `CATALOG`, `search()`, `get()`, `install()`, `installed_skills()`.
 - **`specsmith chat --interactive` stdin decision protocol** — when launched with `--interactive`, the chat command reads JSONL decision events from stdin so an IDE consumer (e.g. the VS Code extension) can drive the safe-mode approval flow and the inline diff review. The new `--decision-timeout <seconds>` flag bounds the wait. Approved tool calls fall through to the standard tool_call/plan_step/task_complete flow; denied calls emit `task_complete success=False`. The first non-accept `diff_decision` comment is folded into the persisted turn's `reviewer_comment` field so the next harness retry can consume it.
 - **Real chat orchestrator** — new `src/specsmith/agent/chat_runner.py` powers `specsmith chat` with a streaming LLM turn. Provider preference is local-first: Ollama (default `http://127.0.0.1:11434`, model `qwen2.5:7b`), then the `anthropic`, `openai`, and `google-genai` SDKs gated on the corresponding API-key env vars. Tokens are streamed to the existing `EventEmitter` as `token` events, and the model's `Plan: / Files changed: / Test results:` sections feed `specsmith.agent.verifier.score()` so `task_complete.confidence` and the `success` flag now reflect a real verdict. Any provider error or missing SDK transparently falls back to the deterministic stub; set `SPECSMITH_DISABLE_REAL_CHAT=1` to force the stub explicitly (used by the test suite).
@@ -25,14 +19,19 @@ already 0.5.0)._
 - **Tests** — `tests/test_skill_marketplace.py` (18 tests), `tests/test_chat_stdin_protocol.py` (3 tests), and `tests/test_chat_diff_decision.py` (3 tests) cover the new surfaces.
 
 ### Changed
-- **Agent skill adapter renamed** — the integration adapter that previously generated `.warp/skills/SKILL.md` is now named `agent-skill` and writes to `.agents/skills/SKILL.md`. Existing `scaffold.yml` files that still list `warp` continue to work via a backward-compat alias resolved in `specsmith.integrations.get_adapter`. The legacy `.warp/skills/SKILL.md` path is still patched on `specsmith upgrade` for projects that have not yet rebuilt.
-- **Customer-facing docs** — Read the Docs pages (`agent-integrations.md`, `getting-started.md`, `configuration.md`, `commands.md`, `agent-client.md`) and `TESTS.md` no longer reference any specific terminal-AI vendor by name. The `agent-skill` adapter is described as a generic SKILL.md integration for terminal-native AI agents.
-- **REQ-079 / ARCHITECTURE.md cleanup boundary text** — protected-paths description generalised to “third-party agent integration directories (e.g. `.agents/`)”. Defensive code in `agent/cleanup.py` continues to protect both `.agents/` and `.warp/` for users who already have either directory in their project.
-- **`pyproject.toml`** version held at `0.5.0`. `Development Status :: 4 - Beta` classifier preserved (1.0.0 stays deferred per the pre-1.0 stance).
-- **`scaffold.yml`** integration list switched to the new `agent-skill` adapter name in this repo's own scaffold.
+- **`pyproject.toml`** version bumped from `0.5.0` to `0.6.0`. `Development Status :: 4 - Beta` classifier preserved (1.0.0 stays deferred per the pre-1.0 stance).
 
 ### Fixed
 - **`specsmith chat` diff block kwarg** — the inline diff review path called `EventEmitter.diff(path=..., diff=...)` but the helper takes `body=`. The kwarg mismatch was latent because no existing test created a `REQUIREMENTS.md` that triggered scope-matched diff blocks. Fixed in `src/specsmith/cli.py` and exercised by `tests/test_chat_diff_decision.py`.
+
+## [0.5.0] — 2026-04-28
+
+### Changed
+- **Agent skill adapter renamed** — the integration adapter that previously generated `.warp/skills/SKILL.md` is now named `agent-skill` and writes to `.agents/skills/SKILL.md`. Existing `scaffold.yml` files that still list `warp` continue to work via a backward-compat alias resolved in `specsmith.integrations.get_adapter`. The legacy `.warp/skills/SKILL.md` path is still patched on `specsmith upgrade` for projects that have not yet rebuilt.
+- **Customer-facing docs** — Read the Docs pages (`agent-integrations.md`, `getting-started.md`, `configuration.md`, `commands.md`, `agent-client.md`) and `TESTS.md` no longer reference any specific terminal-AI vendor by name. The `agent-skill` adapter is described as a generic SKILL.md integration for terminal-native AI agents.
+- **REQ-079 / ARCHITECTURE.md cleanup boundary text** — protected-paths description generalised to “third-party agent integration directories (e.g. `.agents/`)”. Defensive code in `agent/cleanup.py` continues to protect both `.agents/` and `.warp/` for users who already have either directory in their project.
+- **`pyproject.toml`** version bumped to `0.5.0`. `Development Status :: 4 - Beta` classifier preserved (1.0.0 stays deferred per the pre-1.0 stance).
+- **`scaffold.yml`** integration list switched to the new `agent-skill` adapter name in this repo's own scaffold.
 
 ### Internal
 - New module `src/specsmith/integrations/agent_skill.py` (`AgentSkillAdapter`) replaces `src/specsmith/integrations/warp.py` (file removed). `LEGACY_ALIASES = {"warp": "agent-skill"}` in `src/specsmith/integrations/__init__.py` keeps existing configs working without manual migration.
@@ -526,9 +525,10 @@ already 0.5.0)._
 - **G9**: Session start file list now marks services.md as conditional ("if it exists").
 - **G10**: Open TODOs format specified as `- [ ]` / `- [x]` checkbox syntax.
 
+[0.6.0]: https://github.com/BitConcepts/specsmith/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/BitConcepts/specsmith/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/BitConcepts/specsmith/compare/v0.3.13...v0.4.0
-[Unreleased]: https://github.com/BitConcepts/specsmith/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/BitConcepts/specsmith/compare/v0.6.0...HEAD
 [0.2.3]: https://github.com/BitConcepts/specsmith/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/BitConcepts/specsmith/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/BitConcepts/specsmith/compare/v0.2.0...v0.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specsmith"
-version = "0.5.0"
+version = "0.6.0"
 description = "Applied Epistemic Engineering toolkit — AEE agent sessions, execution profiles, FPGA/HDL governance, tool installer, 50+ CLI commands."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps `specsmith` from **`0.5.0`** to **`0.6.0`** and splits the previously-consolidated `[0.5.0]` CHANGELOG section so:

- `[0.5.0]` keeps **only** the original 0.5.0 release content (agent-skill adapter rename, customer-facing docs scrub, REQ-079 cleanup, scaffold.yml integration list, agent_skill.py module replacement).
- A new `[0.6.0]` section captures the chat orchestrator + skill marketplace + `--interactive` stdin protocol + diff_decision tests + hermetic test fixture + chat diff-block kwarg fix.

The `[0.6.0]` compare link is added to the footer.

## Changes

- `pyproject.toml` — `version = "0.6.0"`.
- `CHANGELOG.md` — `[0.6.0]` and split `[0.5.0]` sections; `[0.6.0]` compare link.

## Verification

- The dev-release CI on `develop` will publish `0.6.0.devN` to PyPI on merge.
- No code changes; the underlying chat orchestrator, skills module, and tests have already been merged and verified green.

Co-Authored-By: Oz <oz-agent@warp.dev>
