### PR TITLE
feat(agent): wire MCP into chat + extend notebook record + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **MCP server announcement in chat sessions (REQ-121).** When `.specsmith/mcp.yml` is present, `specsmith chat` now loads the configured servers via `agent.mcp.load_mcp_tools` and emits a `[mcp servers: <names>]` token at the top of the message block so consumers (and the user) see which external tool surfaces are in play. The Specsmith safety middleware still gates every call.
+- **`specsmith notebook record --session-id <id>`** now reads `.specsmith/sessions/<id>/turns.jsonl` and embeds each turn as a `### <role>` section in the generated `docs/notebooks/<slug>.md`, alongside any `--work-item-id` artifacts. Both flags may be combined; either may be omitted (with a friendlier placeholder when neither is supplied). Closes the gap between TESTS.md TEST-123 and the existing implementation.
+- **`tests/test_phase34_completion.py`** — 12 new pytest cases covering: MCP loader (config-missing, single entry, malformed entries dropped, unparseable yaml, MCPServerSpec round-trip), notebook record (session-turns capture, helpful placeholder), notebook replay (success + missing slug exit-code), `cloud spawn --dry-run` (manifest + tarball + `--help` documents `--endpoint`), and a stubbed `scripts/perf_smoke.py` smoke test that asserts the baseline.json schema without spawning real subprocesses.
+
+### Changed
+- `specsmith chat` imports `load_mcp_tools` and emits the MCP-servers token after the rules-loaded notice.
+- `notebook_record` gained `--session-id` and merges `.specsmith/runs/<WI>/` artifacts and `.specsmith/sessions/<id>/turns.jsonl` content into a single notebook.
+
+### Validation
+- `pytest`: **316 passed, 1 skipped** (was 304; +12 in test_phase34_completion.py).
+- `ruff check` + `ruff format --check`: clean.
+- `mypy src/specsmith/`: same status as develop (no regressions; pre-existing `chat_runner.py` errors only surface when optional `anthropic`/`openai` SDKs are locally installed; CI installs only `[dev]` so `ignore_missing_imports` keeps it green there).
 
 ## [0.6.0] — 2026-04-28
 

--- a/src/specsmith/cli.py
+++ b/src/specsmith/cli.py
@@ -5262,6 +5262,7 @@ def chat_cmd(
     import uuid as _uuid
 
     from specsmith.agent.events import EventEmitter
+    from specsmith.agent.mcp import load_mcp_tools
     from specsmith.agent.memory import append_turn, recent_turns
     from specsmith.agent.router import choose_tier
     from specsmith.agent.rules import load_rules
@@ -5286,6 +5287,14 @@ def chat_cmd(
         emitter.token(msg_block, f"[continuing session {sid}: {len(history)} prior turn(s)]\n")
     if rules_prefix:
         emitter.token(msg_block, "[project rules loaded]\n")
+
+    # Surface configured MCP servers (REQ-121). The actual invocation
+    # path still flows through the safety middleware; here we just announce
+    # availability so consumers can render the list.
+    mcp_tools = load_mcp_tools(root)
+    if mcp_tools:
+        names = ", ".join(t.name for t in mcp_tools)
+        emitter.token(msg_block, f"[mcp servers: {names}]\n")
 
     # Pick a tier (REQ-122) so consumers know which model is in play.
     _utt_lower = utterance.lower()
@@ -5545,13 +5554,27 @@ def notebook_group() -> None:
     default="",
     help="Work item id whose .specsmith/runs/<WI>/ artifacts should be captured.",
 )
-def notebook_record(slug: str, project_dir: str, work_item_id: str) -> None:
+@click.option(
+    "--session-id",
+    "session_id",
+    default="",
+    help="Session id whose .specsmith/sessions/<id>/turns.jsonl should be captured.",
+)
+def notebook_record(slug: str, project_dir: str, work_item_id: str, session_id: str) -> None:
     """Record a notebook for the given SLUG (REQ-123).
 
-    Reads `.specsmith/runs/<work_item_id>/` (logs.txt, decision.json, etc.)
-    and writes a self-contained Markdown notebook to
-    `docs/notebooks/<slug>.md`.
+    Two artifact sources are supported and may be combined:
+
+    * ``--work-item-id`` reads `.specsmith/runs/<WI>/` (preflight/verify
+      logs, decision.json, etc.).
+    * ``--session-id`` reads `.specsmith/sessions/<id>/turns.jsonl` so a
+      conversational chat session can be replayed later.
+
+    Either flag may be omitted; both may be combined to produce a single
+    notebook that captures the full evidence trail.
     """
+    import json as _json
+
     root = Path(project_dir).resolve()
     nb_dir = root / "docs" / "notebooks"
     nb_dir.mkdir(parents=True, exist_ok=True)
@@ -5559,10 +5582,15 @@ def notebook_record(slug: str, project_dir: str, work_item_id: str) -> None:
 
     runs_dir = root / ".specsmith" / "runs"
     artifact_dir = runs_dir / work_item_id if work_item_id else None
-    sections: list[str] = [f"# Notebook — {slug}\n"]
+    sections: list[str] = [f"# Notebook \u2014 {slug}\n"]
     if work_item_id:
         sections.append(f"- **Work item**: `{work_item_id}`")
+    if session_id:
+        sections.append(f"- **Session**: `{session_id}`")
+
+    captured_any = False
     if artifact_dir and artifact_dir.is_dir():
+        captured_any = True
         sections.append("\n## Captured artifacts\n")
         for path in sorted(artifact_dir.rglob("*")):
             if path.is_file():
@@ -5574,10 +5602,30 @@ def notebook_record(slug: str, project_dir: str, work_item_id: str) -> None:
                     continue
                 fence = "```"
                 sections.append(f"### `{rel}`\n\n{fence}\n{body}\n{fence}\n")
-    else:
+
+    if session_id:
+        turns_path = root / ".specsmith" / "sessions" / session_id / "turns.jsonl"
+        if turns_path.is_file():
+            captured_any = True
+            sections.append("\n## Session turns\n")
+            for line in turns_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    turn = _json.loads(line)
+                except ValueError:
+                    continue
+                role = str(turn.get("role", "?"))
+                utterance = str(turn.get("utterance") or turn.get("text") or "").strip()
+                ts = str(turn.get("timestamp", "")).strip()
+                header = f"### `{role}`" + (f" \u2014 {ts}" if ts else "")
+                sections.append(f"{header}\n\n{utterance}\n")
+
+    if not captured_any:
         sections.append(
-            "\n_No `.specsmith/runs/<WI>/` directory found. "
-            "Run `specsmith preflight` and `specsmith verify` first to capture evidence._\n"
+            "\n_No artifacts captured. Pass `--work-item-id <WI>` or "
+            "`--session-id <id>` to populate this notebook._\n"
         )
     target.write_text("\n".join(sections), encoding="utf-8")
     console.print(f"[green]\u2713[/green] Notebook recorded at {target.relative_to(root)}")

--- a/tests/test_phase34_completion.py
+++ b/tests/test_phase34_completion.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+"""Phase 3-4 completion tests: mcp loader, notebook + cloud commands.
+
+Covers REQ-121 (MCP), REQ-123 (notebook), REQ-126 (cloud spawn), REQ-124
+(perf smoke). The CLI commands are exercised through Click's CliRunner so
+the tests stay fully hermetic — no real subprocess, no real PyPI hits.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from specsmith.agent.mcp import (
+    MCPServerSpec,
+    MCPTool,
+    load_mcp_tools,
+)
+from specsmith.cli import main
+
+# ── MCP loader (REQ-121 / TEST-121) ──────────────────────────────────────────
+
+
+def test_load_mcp_tools_returns_empty_when_config_missing(tmp_path: Path) -> None:
+    """No `.specsmith/mcp.yml` => empty list, not an error."""
+    assert load_mcp_tools(tmp_path) == []
+
+
+def test_load_mcp_tools_parses_one_entry(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / ".specsmith"
+    cfg_dir.mkdir()
+    (cfg_dir / "mcp.yml").write_text(
+        "- name: filesystem\n"
+        "  command: mcp-server-filesystem\n"
+        "  args: ['--root', '.']\n"
+        "  env:\n"
+        "    HOME: /tmp\n",
+        encoding="utf-8",
+    )
+    tools = load_mcp_tools(tmp_path)
+    assert len(tools) == 1
+    tool = tools[0]
+    assert isinstance(tool, MCPTool)
+    assert tool.name == "filesystem"
+    assert tool.spec.command == "mcp-server-filesystem"
+    assert tool.spec.args == ["--root", "."]
+    assert tool.spec.env == {"HOME": "/tmp"}
+
+
+def test_load_mcp_tools_skips_malformed_entries(tmp_path: Path) -> None:
+    """Entries missing name or command must be silently dropped."""
+    cfg_dir = tmp_path / ".specsmith"
+    cfg_dir.mkdir()
+    (cfg_dir / "mcp.yml").write_text(
+        "- name: ok\n  command: mcp-real\n- command: nameless\n- name: commandless\n- not_a_dict\n",
+        encoding="utf-8",
+    )
+    tools = load_mcp_tools(tmp_path)
+    assert [t.name for t in tools] == ["ok"]
+
+
+def test_load_mcp_tools_returns_empty_on_unparseable_yaml(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / ".specsmith"
+    cfg_dir.mkdir()
+    (cfg_dir / "mcp.yml").write_text(": : :\n", encoding="utf-8")
+    assert load_mcp_tools(tmp_path) == []
+
+
+def test_mcp_server_spec_round_trip() -> None:
+    spec = MCPServerSpec(name="x", command="y", args=["a"], env={"k": "v"})
+    assert spec.name == "x"
+    assert spec.args == ["a"]
+    assert spec.env == {"k": "v"}
+
+
+# ── Notebook record / replay (REQ-123 / TEST-123) ────────────────────────────
+
+
+def test_notebook_record_with_session_id_captures_turns(tmp_path: Path) -> None:
+    """`--session-id` materialises turns.jsonl as a `## Session turns` section."""
+    sid = "sess_abc"
+    sess_dir = tmp_path / ".specsmith" / "sessions" / sid
+    sess_dir.mkdir(parents=True)
+    turns = [
+        {"role": "user", "utterance": "add hello world", "timestamp": "2026-04-29T00:00:00Z"},
+        {"role": "agent", "utterance": "Plan: write a test", "timestamp": "2026-04-29T00:00:01Z"},
+    ]
+    (sess_dir / "turns.jsonl").write_text(
+        "\n".join(json.dumps(t) for t in turns) + "\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "notebook",
+            "record",
+            "demo",
+            "--project-dir",
+            str(tmp_path),
+            "--session-id",
+            sid,
+        ],
+        env={"SPECSMITH_NO_AUTO_UPDATE": "1", "SPECSMITH_PYPI_CHECKED": "1"},
+    )
+    assert result.exit_code == 0, result.output
+
+    nb = (tmp_path / "docs" / "notebooks" / "demo.md").read_text(encoding="utf-8")
+    assert "# Notebook" in nb
+    assert sid in nb
+    assert "## Session turns" in nb
+    assert "add hello world" in nb
+    assert "Plan: write a test" in nb
+
+
+def test_notebook_record_with_no_artifacts_writes_a_helpful_placeholder(
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["notebook", "record", "empty", "--project-dir", str(tmp_path)],
+        env={"SPECSMITH_NO_AUTO_UPDATE": "1", "SPECSMITH_PYPI_CHECKED": "1"},
+    )
+    assert result.exit_code == 0, result.output
+    nb = (tmp_path / "docs" / "notebooks" / "empty.md").read_text(encoding="utf-8")
+    assert "No artifacts captured" in nb
+
+
+def test_notebook_replay_prints_recorded_notebook(tmp_path: Path) -> None:
+    nb_dir = tmp_path / "docs" / "notebooks"
+    nb_dir.mkdir(parents=True)
+    (nb_dir / "demo.md").write_text("# Notebook — demo\nhello\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["notebook", "replay", "demo", "--project-dir", str(tmp_path)],
+        env={"SPECSMITH_NO_AUTO_UPDATE": "1", "SPECSMITH_PYPI_CHECKED": "1"},
+    )
+    assert result.exit_code == 0
+    assert "hello" in result.output
+
+
+def test_notebook_replay_missing_slug_exits_non_zero(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["notebook", "replay", "ghost", "--project-dir", str(tmp_path)],
+        env={"SPECSMITH_NO_AUTO_UPDATE": "1", "SPECSMITH_PYPI_CHECKED": "1"},
+    )
+    assert result.exit_code == 1
+    assert "No notebook" in result.output
+
+
+# ── Cloud spawn (REQ-126 / TEST-126) ─────────────────────────────────────────
+
+
+def test_cloud_spawn_dry_run_writes_manifest_without_posting(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "cloud",
+            "spawn",
+            "add hello world",
+            "--project-dir",
+            str(tmp_path),
+            "--dry-run",
+        ],
+        env={"SPECSMITH_NO_AUTO_UPDATE": "1", "SPECSMITH_PYPI_CHECKED": "1"},
+    )
+    assert result.exit_code == 0, result.output
+    cloud_root = tmp_path / ".specsmith" / "cloud"
+    assert cloud_root.is_dir()
+    runs = list(cloud_root.iterdir())
+    assert len(runs) == 1, "exactly one run directory should have been created"
+    manifest = json.loads((runs[0] / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["utterance"] == "add hello world"
+    assert manifest["dry_run"] is True
+    assert (runs[0] / "workspace.tar.gz").is_file()
+
+
+def test_cloud_spawn_help_documents_endpoint(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["cloud", "spawn", "--help"])
+    assert result.exit_code == 0
+    assert "--endpoint" in result.output
+    assert "--dry-run" in result.output
+
+
+# ── Perf smoke (REQ-124 / TEST-124) ──────────────────────────────────────────
+
+
+def test_perf_smoke_script_main_writes_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run the perf-smoke script's main() with a tiny REQ count and a stubbed
+    `_time_preflight` so the test never spawns a real subprocess.
+
+    Verifies that ``baseline.json`` is written with the expected schema.
+    """
+    import importlib.util
+
+    perf_path = Path(__file__).resolve().parent.parent / "scripts" / "perf_smoke.py"
+    spec = importlib.util.spec_from_file_location("perf_smoke", perf_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # Replace the slow subprocess call with a deterministic stub.
+    monkeypatch.setattr(module, "_time_preflight", lambda *_a, **_k: 0.05)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sys.argv", ["perf_smoke.py", "--reqs", "5", "--project-dir", str(tmp_path)]
+    )
+
+    rc = module.main()
+    assert rc == 0
+
+    baseline = json.loads(
+        (tmp_path / ".specsmith" / "perf" / "baseline.json").read_text(encoding="utf-8")
+    )
+    assert baseline["n_reqs"] == 5
+    assert len(baseline["timings_seconds"]) == 3
+    assert baseline["median_seconds"] == pytest.approx(0.05, abs=1e-3)


### PR DESCRIPTION
## Summary

Phase 3-4 completion work for the existing `agent.{rules,memory,router,mcp,notebook,cloud}` modules already on develop. Wires MCP into `specsmith chat`, extends `notebook record` to read session turns, and adds 12 new pytest cases for the previously untested surfaces.

**No version bump** — this is develop-only completion work, per repo policy.

## Changes

**`src/specsmith/cli.py`**
- `chat_cmd` imports `from specsmith.agent.mcp import load_mcp_tools` and emits a `[mcp servers: <names>]` token after the rules-loaded notice. Safety middleware still gates every call.
- `notebook_record` gained `--session-id <id>` so it can read `.specsmith/sessions/<id>/turns.jsonl` and embed each turn as a `### <role>` Markdown section. `--work-item-id` and `--session-id` may be combined; either may be omitted; if neither is supplied the notebook gets a friendly placeholder.

**`tests/test_phase34_completion.py`** (new) — 12 cases:
- MCP loader: config-missing → empty, single-entry parsing, malformed entries dropped, unparseable yaml → empty, `MCPServerSpec` round-trip.
- Notebook: `record --session-id` captures turns; `record` without flags writes placeholder; `replay` prints body; `replay` of missing slug exits non-zero.
- Cloud: `cloud spawn --dry-run` writes manifest + tarball without posting; `cloud spawn --help` documents `--endpoint` + `--dry-run`.
- Perf: `scripts/perf_smoke.py` `main()` produces `baseline.json` with the documented schema (subprocess stubbed).

**`CHANGELOG.md`** — `[Unreleased]` entry under `## [Unreleased]` describing the above. No `## [0.x.y]` heading bump.

## Validation

- `pytest`: **316 passed, 1 skipped** (was 304; +12 new).
- `ruff check src tests scripts`: clean.
- `ruff format --check src tests scripts`: 139 files already formatted.
- `mypy src/specsmith/`: identical to develop (3 pre-existing chat_runner errors only surface when optional `anthropic`/`openai` SDKs are locally installed; CI installs only `[dev]` and uses `ignore_missing_imports`).

## Out of scope

- Version bump (per repo policy: develop → unstable, main → stable; rev only on explicit ask).
- Real (non-stubbed) MCP `tools/call` round-trip — the loader test covers configuration; runtime invocation is exercised through the existing safety middleware path. Live integration smoke tests are tracked separately under REQ-121 future work.

---

Plan: [specsmith → 1.0 + Warp-level Agentic Workbench: Full Roadmap](https://app.warp.dev/drive/notebook/WT8Mspj5xajKDIBDRTkerU)
Conversation: [warp.dev](https://app.warp.dev/conversation/6f8aa790-049b-4ddf-9c52-4840728faee5)

Co-Authored-By: Oz <oz-agent@warp.dev>
