### PR TITLE
chore(release): specsmith 0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ temp/
 # Secrets and local-only Nexus artifacts
 .env
 .repo-index/
+
+# Test-generated cloud spawn manifests
+.specsmith/cloud/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] — 2026-04-30
 ### Added
 - **`specsmith serve --auth-token` (REQ-137).** Optional bearer-token gate on every `/api/*` endpoint. `/api/health` stays open so liveness probes still work behind a load balancer that strips `Authorization`. New `make_server()` factory in `src/specsmith/serve.py` exposes a fully wired server for tests; `run_server()` adds the banner + `serve_forever` loop. `_Handler._authorize()` enforces `Authorization: Bearer <token>` on `do_GET`, `do_POST`, and `do_DELETE`.
 - **`specsmith voice transcribe <wav>` (REQ-141).** New `src/specsmith/agent/voice.py` wraps the optional `whisper-cpp-python` extra. Three resolution modes: real (library + model file under `~/.specsmith/voice/` or `SPECSMITH_VOICE_MODEL`), stub (`SPECSMITH_VOICE_STUB=<text>` for tests/CI), or unavailable (raises `VoiceUnavailableError` with an actionable install hint). CLI exposes `voice transcribe --json` and `voice status`.
@@ -558,7 +559,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.6.0]: https://github.com/BitConcepts/specsmith/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/BitConcepts/specsmith/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/BitConcepts/specsmith/compare/v0.3.13...v0.4.0
-[Unreleased]: https://github.com/BitConcepts/specsmith/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/BitConcepts/specsmith/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/BitConcepts/specsmith/compare/v0.6.0...v0.7.0
 [0.2.3]: https://github.com/BitConcepts/specsmith/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/BitConcepts/specsmith/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/BitConcepts/specsmith/compare/v0.2.0...v0.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specsmith"
-version = "0.6.0"
+version = "0.7.0"
 description = "Applied Epistemic Engineering toolkit — AEE agent sessions, execution profiles, FPGA/HDL governance, tool installer, 50+ CLI commands."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Tag-bump release. All the feature work shipped under previous PRs (#86, #87, #88, #89). This PR just promotes the `[Unreleased]` CHANGELOG section to `[0.7.0]` and bumps `pyproject.toml`.

## Highlights of 0.7.0

* REQ-130: real MCP JSON-RPC client
* REQ-131: `specsmith suggest-command` NL-to-command suggester
* REQ-133: Specsmith Drive (`drive push` / `pull` / `listing`)
* REQ-134: `specsmith chat-export-block` block share
* REQ-135: `specsmith history search` (keyword + optional semantic)
* REQ-136: `specsmith cloud spawn` (manifest-based, bearer auth)
* REQ-137: `specsmith serve --auth-token` (bearer auth gate)
* REQ-140: `specsmith api-surface` (1.0 stability snapshot)
* REQ-141: `specsmith voice transcribe` (whisper-cpp wrapper)

## Validation

* `pytest` -> 376 passed, 1 skipped
* `ruff check` + `ruff format --check` -> clean
* `mypy src/specsmith/` -> clean

Co-Authored-By: Oz <oz-agent@warp.dev>