### PR TITLE
chore(windows): UTF-8 dev wrappers for pytest / ruff

### DIFF
--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -1,0 +1,64 @@
+# Developer scripts (Windows UTF-8 hygiene)
+The default Windows console is configured for legacy code pages (cp437 /
+cp1252), which mangles UTF-8 output from Python, pytest, ruff, and
+similar tools. The pytest reporter becomes `ΓêÜ` instead of `✓` and
+em-dashes in ledger / changelog tooling become `ΓÇö`.
+
+These scripts work around that without forcing every contributor to edit
+their PowerShell `$PROFILE`.
+
+## Quick reference
+| What you want | Run this |
+|---|---|
+| Run pytest with proper Unicode in PowerShell | `.\scripts\dev\test.ps1` |
+| Run pytest with arguments forwarded | `.\scripts\dev\test.ps1 -k history -v` |
+| Run ruff check + format check | `.\scripts\dev\lint.ps1` |
+| Run pytest from cmd.exe | `scripts\dev\test.cmd` |
+| Just fix encoding in your current shell | `. .\scripts\dev\Set-Utf8Encoding.ps1` |
+
+## What the scripts do
+Each wrapper dot-sources `Set-Utf8Encoding.ps1` first, which:
+
+* Switches the active code page to 65001 (`chcp 65001`).
+* Sets `[Console]::OutputEncoding` and `[Console]::InputEncoding` to UTF-8.
+* Sets `$OutputEncoding` to UTF-8 (covers PowerShell 5.1 too).
+* Sets `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` so child Python
+  processes emit UTF-8 regardless of the system locale.
+
+After the encoding is fixed, the wrappers call `py -m pytest` (or
+`py -m ruff`) with any arguments you passed.
+
+## Permanent fix (recommended for daily Windows pwsh users)
+Add this to your PowerShell `$PROFILE` so every new shell starts in
+UTF-8 mode:
+
+```pwsh
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+[Console]::InputEncoding  = [System.Text.UTF8Encoding]::new()
+$OutputEncoding           = [System.Text.UTF8Encoding]::new()
+$env:PYTHONUTF8           = '1'
+$env:PYTHONIOENCODING     = 'utf-8'
+$null = & chcp.com 65001
+```
+
+Edit it with: `notepad $PROFILE` (creating the file if needed). After
+saving, open a fresh shell and verify with:
+
+```pwsh
+chcp                                            # Active code page: 65001
+[Console]::OutputEncoding.WebName               # utf-8
+$env:PYTHONUTF8                                 # 1
+```
+
+Once the profile is in place you can run `py -m pytest` directly without
+any wrapper.
+
+## Why dot-source `Set-Utf8Encoding.ps1`?
+PowerShell scripts run in a child scope by default, so changes to
+`[Console]::OutputEncoding` etc. would only affect the script process and
+not the caller. Dot-sourcing (`. .\Set-Utf8Encoding.ps1`) runs the script
+in the current scope so the encoding settings persist for subsequent
+commands you type into the same shell.
+
+The wrapper scripts (`test.ps1`, `lint.ps1`) handle the dot-sourcing
+internally so you don't need to remember it for routine use.

--- a/scripts/dev/Set-Utf8Encoding.ps1
+++ b/scripts/dev/Set-Utf8Encoding.ps1
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+#
+# Set the current PowerShell session to UTF-8 input/output encoding so child
+# processes (Python, pytest, ruff, mypy, ...) that emit UTF-8 text don't
+# render as mojibake (e.g. `ΓêÜ` instead of `✓`, `ΓÇö` instead of `—`,
+# `Γåô` instead of `→`).
+#
+# Why this is needed:
+#   PowerShell on Windows defaults `[Console]::OutputEncoding` to the active
+#   OEM code page (cp437 / cp1252). When pytest writes UTF-8 bytes to its
+#   stdout, PowerShell decodes them with that legacy code page and the
+#   multi-byte sequences appear as garbage. PowerShell 7.4+ improves this
+#   only for `$OutputEncoding` (the encoding PowerShell uses to *send* data
+#   to children); the receive path still respects the active code page.
+#
+# What this script does:
+#   * Switches the active code page to 65001 (UTF-8) via `chcp` so console
+#     APIs and child cmd.exe invocations agree on UTF-8.
+#   * Sets `[Console]::OutputEncoding` and `[Console]::InputEncoding` to
+#     UTF-8 so PowerShell decodes incoming child stdout/stderr as UTF-8.
+#   * Sets `$OutputEncoding` (used when piping into native commands) to
+#     UTF-8 too. Modern PowerShell already defaults this to UTF-8 but we
+#     re-assert it for older 5.1 sessions.
+#   * Sets `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` so Python sub-shells
+#     emit UTF-8 regardless of the locale settings.
+#
+# Usage:
+#   PS> . .\scripts\dev\Set-Utf8Encoding.ps1
+#   PS> py -m pytest        # ✓ / ✗ / — render correctly
+#
+# This is dot-sourced (note the leading `.`) so the encoding changes apply
+# to the calling shell. Running it without dot-sourcing affects only the
+# child PowerShell process and is a no-op for the caller.
+#
+# Idempotent: re-running when already in UTF-8 mode is a no-op.
+
+$null = & chcp.com 65001 2>&1
+
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+[Console]::InputEncoding  = [System.Text.UTF8Encoding]::new()
+$OutputEncoding           = [System.Text.UTF8Encoding]::new()
+
+# Python UTF-8 mode — Python 3.7+ honours both env vars. PYTHONUTF8=1
+# enables UTF-8 mode globally; PYTHONIOENCODING covers stdin/stdout/stderr
+# specifically and is older / more widely supported.
+$env:PYTHONUTF8 = '1'
+$env:PYTHONIOENCODING = 'utf-8'
+
+if ($Host.UI.RawUI -and -not [Environment]::CommandLine.Contains('-NonInteractive')) {
+  Write-Host "[utf8] active code page: 65001 ; PYTHONUTF8=1" -ForegroundColor DarkGreen
+}

--- a/scripts/dev/lint.ps1
+++ b/scripts/dev/lint.ps1
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+#
+# Run ruff check + ruff format --check under UTF-8 so any Unicode in error
+# messages or rule descriptions renders correctly.
+
+. "$PSScriptRoot\Set-Utf8Encoding.ps1"
+
+py -m ruff check src tests
+$ruffCheckExit = $LASTEXITCODE
+py -m ruff format --check src tests
+$ruffFormatExit = $LASTEXITCODE
+
+if ($ruffCheckExit -ne 0 -or $ruffFormatExit -ne 0) {
+  exit ($ruffCheckExit -bor $ruffFormatExit)
+}
+exit 0

--- a/scripts/dev/test.cmd
+++ b/scripts/dev/test.cmd
@@ -1,0 +1,14 @@
+@echo off
+rem SPDX-License-Identifier: MIT
+rem Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+rem
+rem cmd.exe wrapper for pytest that switches the current console to UTF-8
+rem (code page 65001) and forces Python's stdout/stderr to UTF-8 so the
+rem test reporter doesn't render as mojibake. Use the PowerShell wrapper
+rem if you're on pwsh.
+
+chcp 65001 > NUL
+set PYTHONUTF8=1
+set PYTHONIOENCODING=utf-8
+py -m pytest %*
+exit /b %ERRORLEVEL%

--- a/scripts/dev/test.ps1
+++ b/scripts/dev/test.ps1
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+#
+# Run pytest with the active PowerShell session reconfigured for UTF-8 so
+# the test reporter, ruff output, and any Unicode in test fixtures render
+# correctly on Windows.
+#
+# Usage:
+#   PS> .\scripts\dev\test.ps1                # py -m pytest
+#   PS> .\scripts\dev\test.ps1 -k history     # forwards args verbatim
+#   PS> .\scripts\dev\test.ps1 tests/test_warp_parity_followup.py -v
+
+. "$PSScriptRoot\Set-Utf8Encoding.ps1"
+
+py -m pytest @args
+exit $LASTEXITCODE


### PR DESCRIPTION
Fixes the Windows console encoding issue where `py -m pytest` and `py -m ruff` output renders as mojibake on PowerShell sessions whose code page is the default cp437 / cp1252.

## What ships
* `scripts/dev/Set-Utf8Encoding.ps1` — dot-sourceable helper that sets the active code page to 65001, `[Console]::OutputEncoding` and `\System.Text.UTF8Encoding+UTF8EncodingSealed` to UTF-8, plus `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` so child Python processes also use UTF-8.
* `scripts/dev/test.ps1` — wrapper that dot-sources the helper then runs `py -m pytest` with all args forwarded.
* `scripts/dev/lint.ps1` — wrapper that runs `ruff check` + `ruff format --check`.
* `scripts/dev/test.cmd` — cmd.exe equivalent.
* `scripts/dev/README.md` — explanation + permanent `\C:\Users\trist\OneDrive\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` recipe.

## Why npm-style aliases don't work
A child process cannot change its parent PowerShell's `[Console]::OutputEncoding`. Only PowerShell scripts that **dot-source** into the calling shell, or a one-time edit to the user's `\C:\Users\trist\OneDrive\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`, actually fix the rendering.

Co-Authored-By: Oz <oz-agent@warp.dev>