### PR TITLE
feat(0.10.1): G1-G4 + C1 + H1-H4 follow-up sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ specsmith treats belief systems like code: codable, testable, and deployable. It
 epistemically-governed projects, stress-tests requirements as BeliefArtifacts, runs
 cryptographically-sealed trace vaults, and orchestrates AI agents under formal AEE governance.
 
+**0.10.0 — Multi-Agent + BYOE.** A `/plan` goes to the architect, `/fix`
+goes to the coder, `/review` goes to a reviewer that runs on a different
+model family. Each *profile* is a `(provider, model, endpoint?, fallback_chain)`
+bundle stored in `~/.specsmith/agents.json`; an *activity routing table*
+maps slash commands and AEE phases to profiles; **BYOE endpoints**
+(`~/.specsmith/endpoints.json`) let you point a profile at any
+OpenAI-v1-compatible backend you self-host (vLLM, llama.cpp `server`,
+LM Studio, TGI, ...). Cross-family **diversity guard**, capability
+filtering, transient-failure fallback chains, and TraceVault decision
+seals on every `/agent` pin are wired in by default. See
+[`docs/site/agents.md`](docs/site/agents.md) for the five-minute walkthrough.
+
+```bash
+specsmith agents preset apply default       # frontier coder + cross-family reviewer
+specsmith endpoints add --id home-vllm \
+  --base-url http://10.0.0.4:8000/v1 --auth bearer-keyring
+specsmith run --agent opus-reviewer         # one-shot per-session pin
+```
+
 It also co-installs the standalone `epistemic` Python library for direct use in any project:
 
 ```python

--- a/docs/site/agents.md
+++ b/docs/site/agents.md
@@ -1,0 +1,180 @@
+# Multi-Agent Profiles & Activity Routing
+
+`specsmith agents` (REQ-146) lets you bind activities — a slash command, an
+AEE phase, an MCP tool category — to a named **profile**: a
+`(provider, model, endpoint_id?, prompt_prefix, capabilities, fallback_chain)`
+bundle. The runner consults the routing table on every turn so a `/plan`
+goes to the architect, `/fix` goes to the coder, and `/review` goes to a
+reviewer that runs on a *different* model family.
+
+This page walks you from **install → preset → custom profile → per-session
+override → BYOE endpoint** in five minutes.
+
+---
+
+## 1. Install a preset
+
+Profiles are stored in `~/.specsmith/agents.json`. The fastest way to seed
+the file is to apply one of the four built-in presets:
+
+```bash
+specsmith agents preset list
+specsmith agents preset apply default          # frontier + local fallback (recommended)
+specsmith agents preset apply local-only       # 100% Ollama
+specsmith agents preset apply frontier-only    # Claude Opus everywhere
+specsmith agents preset apply cost-conscious   # Haiku coder, Sonnet architect
+```
+
+After applying:
+
+```bash
+specsmith agents list
+* coder          role=coder       anthropic/claude-sonnet-4-5
+                fallback: mistral/codestral-latest → ollama/qwen2.5-coder:32b
+  architect      role=architect   anthropic/claude-opus-4
+                fallback: openai/gpt-5 → ollama/qwen2.5:32b
+  reviewer       role=reviewer    openai/gpt-5-codex     ← different family!
+  …
+```
+
+The `*` marks the **default profile**, used when no route matches.
+
+---
+
+## 2. Inspect & customise the routing table
+
+```bash
+specsmith agents route show
+* chat                 → coder
+  /plan                → architect
+  /fix                 → coder
+  /review              → reviewer
+  phase:requirements   → researcher
+  …
+```
+
+Re-bind any activity:
+
+```bash
+specsmith agents route set /review opus-reviewer
+specsmith agents route clear /audit
+```
+
+The `phase:<key>` routes are auto-maintained: `specsmith phase next` (G3)
+also pins a `phase:active` route to the new phase's preferred profile so
+the runner can flip the whole session by listening for one activity.
+
+---
+
+## 3. Add your own profile
+
+```bash
+specsmith agents add \
+  --id sonnet-coder \
+  --role coder \
+  --provider anthropic \
+  --model claude-sonnet-4-5 \
+  --capability code \
+  --capability function-calling \
+  --fallback ollama/qwen2.5-coder:32b
+```
+
+If your new coder shares a provider family with the existing reviewer,
+the **diversity guard** (G1) prints a warning so the cross-check the
+reviewer is supposed to provide doesn't degenerate:
+
+```
+✓ saved profile sonnet-coder
+⚠ reviewer (reviewer, anthropic/claude-opus-4) shares the 'anthropic'
+  family with sonnet-coder (coder, anthropic/claude-sonnet-4-5);
+  diversity is recommended so the reviewer can catch the coder's blind spots.
+```
+
+The warning is non-fatal — the profile still saves — but you should
+either pick a reviewer in a different family or accept the trade-off
+deliberately.
+
+### Filter by capability
+
+```bash
+specsmith agents list --capability code-review
+specsmith agents list --capability mcp --json
+```
+
+`--capability` is the easiest way to find every profile that advertises
+a given strength so the right `route set` command writes itself.
+
+---
+
+## 4. Per-session overrides
+
+Three knobs override the routing table for one session:
+
+```bash
+specsmith run --agent opus-reviewer       # pin a profile
+specsmith chat --agent haiku-coder        # one-shot
+specsmith run --endpoint home-vllm        # pin a BYOE endpoint
+```
+
+Inside a running session, the slash command `/agent <id>` flips the
+profile mid-session:
+
+```
+nexus> /agent opus-reviewer
+ℹ profile = opus-reviewer
+```
+
+Pinning a profile via `/agent` writes a **TraceVault decision seal**
+(G4) into `.specsmith/trace.jsonl`, so every "I switched to model X for
+this turn" choice is cryptographically chained into the audit trail.
+You can confirm with `specsmith trace log --type decision`.
+
+### Token accounting (C1)
+
+The runner now reports real `tokens_in` / `tokens_out` for every turn
+on every provider that exposes them (Ollama via `prompt_eval_count` +
+`eval_count`, Anthropic via `final_message.usage`, OpenAI via
+`stream_options.include_usage`, Gemini via `usage_metadata`). When the
+SDK omits usage, a 4-chars/token fallback gives the TokenMeter chip a
+non-zero value to show. Per-profile totals show up in
+`AgentState.by_profile` and the VS Code TokenMeter splits accordingly.
+
+---
+
+## 5. Bring-Your-Own-Endpoint (BYOE)
+
+A **profile** can bind to a registered OpenAI-v1-compatible endpoint
+instead of a built-in provider:
+
+```bash
+# Register the endpoint once
+specsmith endpoints add \
+  --id home-vllm \
+  --base-url http://10.0.0.4:8000/v1 \
+  --default-model qwen2.5-coder \
+  --auth bearer-keyring          # token prompted, stored in OS keyring
+
+# Bind a profile to it
+specsmith agents add \
+  --id local-coder \
+  --role coder \
+  --provider openai-compat \
+  --endpoint home-vllm \
+  --fallback ollama/qwen2.5-coder:7b
+
+specsmith agents route set /code local-coder
+```
+
+The runner now routes `/code` through `home-vllm`. If the box is
+unreachable, the fallback chain walks `ollama/qwen2.5-coder:7b` next
+(see `tests/test_fallback_chain.py` for the full retry policy: 408,
+429, and 5xx fall through, 4xx surfaces immediately).
+
+---
+
+## Reference
+
+- [REQ-146 — Agent profiles + activity routing](../REQUIREMENTS.md)
+- [`specsmith.agent.profiles`](../../src/specsmith/agent/profiles.py) — `Profile`, `ProfileStore`, `apply_preset`, `provider_family`
+- [`specsmith.agent.fallback`](../../src/specsmith/agent/fallback.py) — `run_with_fallback`, `parse_target`
+- [`docs/site/api-stability.md`](api-stability.md) — public surface contract

--- a/docs/site/quickstart.md
+++ b/docs/site/quickstart.md
@@ -1,0 +1,108 @@
+# Five-Minute Quickstart
+This page is the **reproducible** version of the README's elevator pitch:
+copy the commands top-to-bottom and you'll end up with a fresh project,
+a multi-agent profile set, a routed `/plan` → architect → coder pipeline,
+and a TraceVault sealed audit chain you can verify after the fact.
+
+> **GIF placeholder.** A 30-second screen recording showing the same
+> commands running end-to-end will live at
+> `docs/site/_static/quickstart.gif`. Until that lands, the script in
+> [scripts/quickstart.sh](#reproduction-script) is the source of truth.
+
+---
+
+## Prerequisites
+- Python 3.10+ (`pipx install specsmith` or `pip install specsmith`)
+- One LLM provider configured (any of):
+  - `ANTHROPIC_API_KEY=sk-…` for Claude
+  - `OPENAI_API_KEY=sk-…` for GPT/O-series
+  - `GOOGLE_API_KEY=…` for Gemini
+  - Ollama running locally (`ollama serve`) — no key needed
+
+The reproduction script intentionally has *no* timing-sensitive steps so
+it's safe to run unattended in CI.
+
+---
+
+## Reproduction script
+```bash
+#!/usr/bin/env bash
+# scripts/quickstart.sh — five-minute walkthrough, idempotent.
+set -euo pipefail
+export SPECSMITH_NO_AUTO_UPDATE=1
+export SPECSMITH_PYPI_CHECKED=1
+
+# 1. Scaffold a fresh project.
+specsmith init --output-dir /tmp \
+  --config <(cat <<'YAML'
+name: quickstart-demo
+type: cli-python
+language: python
+description: "specsmith multi-agent quickstart demo"
+YAML
+)
+cd /tmp/quickstart-demo
+
+# 2. Install the recommended profile preset.
+specsmith agents preset apply default
+specsmith agents list
+specsmith agents route show
+
+# 3. Add a custom local-coder profile (diversity guard fires).
+specsmith agents add \
+  --id local-coder \
+  --role coder \
+  --provider ollama \
+  --model qwen2.5-coder:32b \
+  --capability code \
+  --fallback ollama/qwen2.5-coder:7b
+
+# 4. Filter by capability — handy for finding "what can do X".
+specsmith agents list --capability code --json
+
+# 5. Optional: register a self-hosted endpoint (BYOE).
+# specsmith endpoints add \
+#   --id home-vllm \
+#   --base-url http://10.0.0.4:8000/v1 \
+#   --default-model qwen2.5-coder \
+#   --auth bearer-keyring
+
+# 6. Drive a single turn through the routing table.
+echo "/plan add a hello-world handler" | \
+  specsmith run --json-events --task "/plan add a hello-world handler"
+
+# 7. Pin a profile mid-session — emits a TraceVault decision seal.
+echo "/agent opus-reviewer" | specsmith run --json-events
+specsmith trace log --type decision
+
+# 8. Advance the AEE phase — auto-routes phase:active to the new phase.
+specsmith phase next --force
+specsmith agents route show | grep phase:active
+```
+
+Save the script anywhere on your machine and run it; the only side
+effects are inside `/tmp/quickstart-demo`, `~/.specsmith/agents.json`,
+and (if you uncomment step 5) `~/.specsmith/endpoints.json`.
+
+---
+
+## What you should see
+| Step | Expected output                                                                 |
+|------|---------------------------------------------------------------------------------|
+| 1    | `Done. N files created in /tmp/quickstart-demo`                                 |
+| 2    | `✓ applied preset default — 7 profiles, 22 routes`                              |
+| 3    | `✓ saved profile local-coder` *plus* a yellow `⚠ … shares the 'ollama' family…` diversity warning if a same-family reviewer exists. |
+| 4    | A JSON document with one entry whose `id` is `local-coder`.                     |
+| 6    | A JSONL stream beginning with `{"type": "ready", …}` followed by `block_start`, `token`, `block_complete`, `task_complete`. |
+| 7    | `✓ Sealed as SEAL-0001` (or whichever sequence number is next).                |
+| 8    | A `phase:active` line in the routing table pointing at the new phase's profile. |
+
+If any step fails, run `specsmith doctor --onboarding` to surface what's
+missing and re-run from that step.
+
+---
+
+## Next steps
+- [`docs/site/agents.md`](agents.md) — the full multi-agent walkthrough
+- [`docs/site/api-stability.md`](api-stability.md) — the public surface contract
+- [`docs/site/vscode-extension.md`](vscode-extension.md) — VS Code Workbench surfaces

--- a/docs/site/vscode-extension.md
+++ b/docs/site/vscode-extension.md
@@ -233,6 +233,34 @@ installed model list before spawning the session.
 
 ---
 
+## Multi-Agent + BYOE Surfaces (0.10.0)
+The extension exposes the CLI's `agents` (REQ-146) and `endpoints` (REQ-142)
+stores as two sidebar trees plus eight Command Palette entries. Each
+command shells out to `specsmith <subcommand> --json` so the on-disk
+schema lives in exactly one place.
+### Sidebar trees
+- **BYOE Endpoints** (`specsmith.endpoints` view) — every entry from
+  `~/.specsmith/endpoints.json`; the entry marked `★` is the default.
+- **Agent Profiles** (`specsmith.agents` view) — grouped under *Profiles*
+  (with `★` on the default) and *Routes* (`activity → profile_id`).
+### Commands
+| Command palette                                  | Action                                                                |
+|--------------------------------------------------|------------------------------------------------------------------------|
+| `specsmith: BYOE Endpoints…`                     | Quick Pick over endpoints with copy-id / set-default / test actions.   |
+| `specsmith: Test BYOE Endpoint`                  | Probes `/v1/models`; toast shows latency + model count.                |
+| `specsmith: Refresh BYOE Endpoints`              | Re-runs `specsmith endpoints list --json` and refreshes the tree.      |
+| `specsmith: Agent Profiles…`                     | Quick Pick over profiles; copy id, set default, route to activity.     |
+| `specsmith: Test Agent Profile`                  | Probes the resolved provider / endpoint and shows reachability.        |
+| `specsmith: Refresh Agent Profiles`              | Re-runs `specsmith agents list --json` and refreshes the tree.         |
+| `specsmith: Apply Agent Preset (default / local-only / frontier-only / cost-conscious)` | Runs `specsmith agents preset apply <name>`.                           |
+| `specsmith: Route Activity to Agent Profile`     | Picks an activity (`/plan`, `/fix`, `phase:requirements`, …) and a profile, then runs `specsmith agents route set`. |
+| `specsmith: Pick Session Profile`                | Per-session pin for the active SessionPanel; appends `--agent <id>` to the bridge invocation. |
+The SessionPanel header chip surfaces the resolved profile + endpoint for
+the current turn; click it to open the picker without leaving the chat.
+### `/agent <id>` from chat
+Typing `/agent opus-reviewer` in the chat input flips the active session
+to the named profile and writes a TraceVault decision seal so the change
+is chained into `.specsmith/trace.jsonl`.
 ## Keyboard Shortcuts
 
 | Shortcut | Action |

--- a/src/specsmith/agent/chat_runner.py
+++ b/src/specsmith/agent/chat_runner.py
@@ -53,6 +53,14 @@ class ChatRunResult:
     files_changed: list[str] = field(default_factory=list)
     verdict: VerifierVerdict | None = None
     raw_text: str = ""
+    # C1: per-turn token + cost accounting. Populated by the provider
+    # driver when it can read counters from the response (Ollama and
+    # Anthropic both expose them). Falls back to a deterministic char-
+    # based heuristic so the TokenMeter chip is never zero on Ollama or
+    # OpenAI-compat endpoints that don't surface usage in streaming mode.
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -61,6 +69,9 @@ class ChatRunResult:
             "files_changed": list(self.files_changed),
             "confidence": self.verdict.confidence if self.verdict else 0.0,
             "equilibrium": self.verdict.equilibrium if self.verdict else False,
+            "tokens_in": int(self.tokens_in),
+            "tokens_out": int(self.tokens_out),
+            "cost_usd": float(self.cost_usd),
         }
 
 
@@ -103,22 +114,51 @@ def run_chat(
             endpoint = None
         if endpoint is not None:
             try:
-                full_text = _run_openai_compat(messages, emitter, msg_block, endpoint=endpoint)
+                full_text, usage = _run_openai_compat(
+                    messages, emitter, msg_block, endpoint=endpoint
+                )
             except Exception:  # noqa: BLE001 - degrade to auto-detect
-                full_text = None
+                full_text, usage = None, _UsageDelta()
             if full_text is not None:
-                return _finalize(full_text, "openai_compat", project_dir, confidence_target)
+                return _finalize(
+                    full_text,
+                    "openai_compat",
+                    project_dir,
+                    confidence_target,
+                    messages=messages,
+                    usage=usage,
+                )
 
     # Order matters: Ollama first because it's local-first and free.
     for provider in (_run_ollama, _run_anthropic, _run_openai, _run_gemini):
         try:
-            full_text = provider(messages, emitter, msg_block)
+            full_text, usage = provider(messages, emitter, msg_block)
         except Exception:  # noqa: BLE001 - any failure → next provider
             continue
         if full_text is None:
             continue
-        return _finalize(full_text, provider.__name__, project_dir, confidence_target)
+        return _finalize(
+            full_text,
+            provider.__name__,
+            project_dir,
+            confidence_target,
+            messages=messages,
+            usage=usage,
+        )
     return None
+
+
+@dataclass
+class _UsageDelta:
+    """Per-turn token + cost counters reported by a provider driver.
+
+    All fields default to ``0`` so callers can construct a zero-value
+    instance without caring whether the provider supports usage tracking.
+    """
+
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
 
 
 def _finalize(
@@ -126,19 +166,45 @@ def _finalize(
     provider_fn_name: str,
     project_dir: Path,
     confidence_target: float,
+    *,
+    messages: list[dict[str, str]] | None = None,
+    usage: _UsageDelta | None = None,
 ) -> ChatRunResult:
     sections = _parse_output_contract(full_text)
     files_changed = _split_files_list(sections.get("files_changed", ""))
     report = report_from_chat_sections(sections, files_changed=files_changed)
     verdict = score(report, confidence_target=confidence_target)
     summary = (sections.get("plan") or full_text.strip()[:200]).strip() or verdict.summary
+
+    # C1: when the provider didn't report exact counts, estimate from text.
+    # The four-chars-per-token rule of thumb is OpenAI's published guidance
+    # and matches Ollama / Anthropic / Gemini within ~10% across the model
+    # families we ship today — close enough for the TokenMeter chip and
+    # the ``credits record`` ledger event.
+    if usage is None:
+        usage = _UsageDelta()
+    if usage.tokens_in == 0 and messages is not None:
+        usage.tokens_in = _estimate_tokens("\n".join(m.get("content", "") for m in messages))
+    if usage.tokens_out == 0:
+        usage.tokens_out = _estimate_tokens(full_text)
+
     return ChatRunResult(
         provider=provider_fn_name.removeprefix("_run_"),
         summary=summary,
         files_changed=files_changed,
         verdict=verdict,
         raw_text=full_text,
+        tokens_in=int(usage.tokens_in),
+        tokens_out=int(usage.tokens_out),
+        cost_usd=float(usage.cost_usd),
     )
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough char→token heuristic (4 chars/token, floor at 1 if non-empty)."""
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
 
 
 # ---------------------------------------------------------------------------
@@ -150,13 +216,14 @@ def _run_ollama(
     messages: list[dict[str, str]],
     emitter: EventEmitter,
     block_id: str,
-) -> str | None:
+) -> tuple[str | None, _UsageDelta]:
     """Stream from a local Ollama daemon using only stdlib."""
     host = os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST).rstrip("/")
     model = os.environ.get("SPECSMITH_OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL)
+    usage = _UsageDelta()
 
     if not _ollama_alive(host):
-        return None
+        return None, usage
 
     payload = json.dumps({"model": model, "messages": messages, "stream": True}).encode("utf-8")
     req = Request(  # noqa: S310 - URL is a hardcoded localhost default
@@ -181,8 +248,13 @@ def _run_ollama(
                 emitter.token(block_id, chunk)
                 pieces.append(chunk)
             if obj.get("done"):
+                # C1: Ollama exposes prompt_eval_count + eval_count on the
+                # final ``done`` message. Cost is zero for local models.
+                usage.tokens_in = int(obj.get("prompt_eval_count") or 0)
+                usage.tokens_out = int(obj.get("eval_count") or 0)
+                usage.cost_usd = 0.0
                 break
-    return "".join(pieces) if pieces else None
+    return ("".join(pieces) if pieces else None), usage
 
 
 def _ollama_alive(host: str) -> bool:
@@ -197,14 +269,15 @@ def _run_anthropic(
     messages: list[dict[str, str]],
     emitter: EventEmitter,
     block_id: str,
-) -> str | None:
+) -> tuple[str | None, _UsageDelta]:
     """Use the anthropic SDK if installed and a key is configured."""
+    usage = _UsageDelta()
     if not os.environ.get("ANTHROPIC_API_KEY"):
-        return None
+        return None, usage
     try:
         import anthropic
     except ImportError:
-        return None
+        return None, usage
 
     system = "\n".join(m["content"] for m in messages if m["role"] == "system")
     user_msgs = [m for m in messages if m["role"] != "system"]
@@ -221,35 +294,54 @@ def _run_anthropic(
             if text:
                 emitter.token(block_id, text)
                 pieces.append(text)
-    return "".join(pieces) if pieces else None
+        # C1: pull final usage off the SDK's `final_message`. Cost is the
+        # caller's problem (rate-limit module knows the model price); we
+        # report tokens here and let the credits ledger compute USD.
+        try:
+            final = stream.get_final_message()
+            usage.tokens_in = int(getattr(final.usage, "input_tokens", 0) or 0)
+            usage.tokens_out = int(getattr(final.usage, "output_tokens", 0) or 0)
+        except Exception:  # noqa: BLE001 - usage is best-effort
+            pass
+    return ("".join(pieces) if pieces else None), usage
 
 
 def _run_openai(
     messages: list[dict[str, str]],
     emitter: EventEmitter,
     block_id: str,
-) -> str | None:
+) -> tuple[str | None, _UsageDelta]:
     """Use the openai SDK if installed and a key is configured."""
+    usage = _UsageDelta()
     if not os.environ.get("OPENAI_API_KEY"):
-        return None
+        return None, usage
     try:
         from openai import OpenAI
     except ImportError:
-        return None
+        return None, usage
 
     client = OpenAI()
+    # ``stream_options.include_usage`` makes the final SSE chunk carry a
+    # populated ``usage`` block (otherwise streaming responses emit it as
+    # ``None``). Older SDK versions silently ignore unknown kwargs.
     stream = client.chat.completions.create(
         model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
         messages=messages,
         stream=True,
+        stream_options={"include_usage": True},
     )
     pieces: list[str] = []
     for chunk in stream:
-        text = (chunk.choices[0].delta.content or "") if chunk.choices else ""
-        if text:
-            emitter.token(block_id, text)
-            pieces.append(text)
-    return "".join(pieces) if pieces else None
+        if chunk.choices:
+            text = chunk.choices[0].delta.content or ""
+            if text:
+                emitter.token(block_id, text)
+                pieces.append(text)
+        usage_obj = getattr(chunk, "usage", None)
+        if usage_obj is not None:
+            usage.tokens_in = int(getattr(usage_obj, "prompt_tokens", 0) or 0)
+            usage.tokens_out = int(getattr(usage_obj, "completion_tokens", 0) or 0)
+    return ("".join(pieces) if pieces else None), usage
 
 
 def _run_openai_compat(
@@ -258,7 +350,7 @@ def _run_openai_compat(
     block_id: str,
     *,
     endpoint: Any,
-) -> str | None:
+) -> tuple[str | None, _UsageDelta]:
     """Stream from a user-registered OpenAI-v1-compatible endpoint (REQ-142).
 
     Uses raw stdlib HTTP so the openai SDK is not a hard dependency for
@@ -266,13 +358,14 @@ def _run_openai_compat(
     Server-Sent-Events ``data:`` lines, and forwards each ``content``
     delta as a ``token`` event on ``block_id``.
     """
+    usage = _UsageDelta()
     base_url = endpoint.base_url.rstrip("/")
     url = f"{base_url}/chat/completions"
     model = endpoint.default_model or os.environ.get("SPECSMITH_OPENAI_COMPAT_MODEL", "")
     if not model:
         # The endpoint did not pin a default model and the env override is
         # absent. We cannot fabricate one; fall back to the auto-detect chain.
-        return None
+        return None, usage
 
     headers: dict[str, str] = {
         "Content-Type": "application/json",
@@ -281,11 +374,20 @@ def _run_openai_compat(
     try:
         token = endpoint.resolve_token()
     except Exception:  # noqa: BLE001 - fall back to auto-detect chain
-        return None
+        return None, usage
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
-    body = json.dumps({"model": model, "messages": messages, "stream": True}).encode("utf-8")
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": messages,
+            "stream": True,
+            # Many vLLM/llama.cpp builds honour OpenAI's stream_options;
+            # the request is harmless if they don't.
+            "stream_options": {"include_usage": True},
+        }
+    ).encode("utf-8")
     req = Request(url, data=body, headers=headers, method="POST")  # noqa: S310 - user-supplied
 
     ctx = None
@@ -313,6 +415,10 @@ def _run_openai_compat(
                 except ValueError:
                     continue
                 choices = obj.get("choices") or []
+                usage_obj = obj.get("usage")
+                if usage_obj:
+                    usage.tokens_in = int(usage_obj.get("prompt_tokens") or 0)
+                    usage.tokens_out = int(usage_obj.get("completion_tokens") or 0)
                 if not choices:
                     continue
                 delta = (choices[0] or {}).get("delta") or {}
@@ -321,35 +427,50 @@ def _run_openai_compat(
                     emitter.token(block_id, chunk)
                     pieces.append(chunk)
     except (URLError, TimeoutError, OSError):
-        return None
-    return "".join(pieces) if pieces else None
+        return None, usage
+    return ("".join(pieces) if pieces else None), usage
 
 
 def _run_gemini(
     messages: list[dict[str, str]],
     emitter: EventEmitter,
     block_id: str,
-) -> str | None:
+) -> tuple[str | None, _UsageDelta]:
     """Use google-genai SDK if installed and a key is configured."""
+    usage = _UsageDelta()
     if not os.environ.get("GOOGLE_API_KEY"):
-        return None
+        return None, usage
     try:
         from google import genai
     except ImportError:
-        return None
+        return None, usage
 
     client = genai.Client()
     prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
     pieces: list[str] = []
+    last_chunk: Any = None
     for chunk in client.models.generate_content_stream(
         model=os.environ.get("GEMINI_MODEL", "gemini-2.5-flash"),
         contents=prompt,
     ):
+        last_chunk = chunk
         text = getattr(chunk, "text", "") or ""
         if text:
             emitter.token(block_id, text)
             pieces.append(text)
-    return "".join(pieces) if pieces else None
+    # Gemini exposes ``usage_metadata`` on the final chunk. Field names
+    # vary across SDK versions; we accept the union.
+    meta = getattr(last_chunk, "usage_metadata", None) if last_chunk else None
+    if meta is not None:
+        usage.tokens_in = int(
+            getattr(meta, "prompt_token_count", 0) or getattr(meta, "input_token_count", 0) or 0
+        )
+        usage.tokens_out = int(
+            getattr(meta, "candidates_token_count", 0)
+            or getattr(meta, "output_token_count", 0)
+            or 0
+        )
+    return ("".join(pieces) if pieces else None), usage
 
 
 # ---------------------------------------------------------------------------

--- a/src/specsmith/agent/profiles.py
+++ b/src/specsmith/agent/profiles.py
@@ -56,6 +56,33 @@ VALID_ROLES = (
     "generalist",
 )
 
+# Provider “family” groupings used by the diversity guard (G1). Profiles in
+# the same family are likely to share training data, system prompt biases,
+# and hallucination patterns — so pairing the coder with a reviewer in the
+# same family defeats the cross-check the reviewer is meant to provide.
+#
+# Anything not listed here is treated as its own family.
+PROVIDER_FAMILIES: dict[str, str] = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "openai-compat": "openai",
+    "azure-openai": "openai",
+    "gemini": "google",
+    "google": "google",
+    "google-genai": "google",
+    "mistral": "mistral",
+    "ollama": "ollama",
+    "llamacpp": "ollama",
+    "vllm": "ollama",
+    "lmstudio": "ollama",
+}
+
+
+def provider_family(provider: str) -> str:
+    """Return the family name for ``provider`` (or the provider verbatim)."""
+    key = (provider or "").strip().lower()
+    return PROVIDER_FAMILIES.get(key, key or "unknown")
+
 
 # Default presets shipped with the CLI so a fresh install Just Works.
 # The exact model strings can be customised per-deployment via
@@ -493,7 +520,64 @@ class ProfileStore:
     def list_all(self) -> list[Profile]:
         return list(self.profiles)
 
-    # ── Routing ───────────────────────────────────────────────────────
+    def filter_by_capability(self, capability: str) -> list[Profile]:
+        """Return profiles whose ``capabilities`` list contains ``capability``.
+
+        Matching is case-insensitive and trims whitespace. An empty
+        ``capability`` argument returns ``[]`` rather than “everything” so
+        callers can distinguish “no filter” (don’t call this method) from
+        “filter for an empty value” (which is never meaningful).
+        """
+        needle = (capability or "").strip().lower()
+        if not needle:
+            return []
+        return [
+            p
+            for p in self.profiles
+            if any(needle == str(c).strip().lower() for c in p.capabilities)
+        ]
+
+    def diversity_warnings(self, *, candidate: Profile | None = None) -> list[str]:
+        """Return a list of plain-English diversity warnings for the store.
+
+        The reviewer profile exists to cross-check the coder; if both call
+        the same provider family the cross-check is degenerate. Same logic
+        applies to architect vs. reviewer (both should be skeptical of the
+        coder). When ``candidate`` is supplied the candidate is added to
+        the population *and* takes precedence over any same-id profile
+        already in the store, so a `specsmith agents add` invocation can
+        preview the warnings *before* writing the store.
+        """
+        population: dict[str, Profile] = {p.id: p for p in self.profiles}
+        if candidate is not None:
+            population[candidate.id] = candidate
+        by_role: dict[str, list[Profile]] = {}
+        for p in population.values():
+            by_role.setdefault(p.role, []).append(p)
+
+        warnings: list[str] = []
+        for left_role, right_role in (
+            ("coder", "reviewer"),
+            ("architect", "reviewer"),
+        ):
+            left = by_role.get(left_role) or []
+            right = by_role.get(right_role) or []
+            if not left or not right:
+                continue
+            for lp in left:
+                lf = provider_family(lp.provider)
+                for rp in right:
+                    if provider_family(rp.provider) == lf:
+                        warnings.append(
+                            f"{rp.id} ({rp.role}, {rp.provider}/{rp.model}) "
+                            f"shares the {lf!r} family with "
+                            f"{lp.id} ({lp.role}, {lp.provider}/{lp.model}); "
+                            "diversity is recommended so the reviewer can catch "
+                            "the coder's blind spots."
+                        )
+        return warnings
+
+    # ── Routing ─────────────────────────────────────────────────
 
     def set_route(self, activity: str, profile_id: str) -> None:
         activity = activity.strip()
@@ -558,6 +642,7 @@ def apply_preset(name: str, *, path: Path | None = None) -> ProfileStore:
 
 __all__ = [
     "DEFAULT_PRESETS",
+    "PROVIDER_FAMILIES",
     "Profile",
     "ProfileError",
     "ProfileStore",
@@ -566,4 +651,5 @@ __all__ = [
     "apply_preset",
     "default_store_path",
     "project_store_path",
+    "provider_family",
 ]

--- a/src/specsmith/agent/runner.py
+++ b/src/specsmith/agent/runner.py
@@ -277,6 +277,13 @@ class AgentRunner:
             self.profile_id = new_profile or None
             self._state.profile_id = new_profile
             self._emit_event(type="system", message=f"profile = {new_profile or '(default)'}")
+            # G4: pin the profile choice into the project trace vault so the
+            # decision “I explicitly asked for profile X here” is
+            # cryptographically chained into the audit trail. Best-effort:
+            # missing TraceVault dependency / read-only filesystem must not
+            # break the chat loop.
+            if new_profile:
+                self._seal_profile_pin(new_profile)
             return None
         if text.startswith("/endpoint "):
             new_endpoint = text.split(maxsplit=1)[1].strip()
@@ -321,14 +328,21 @@ class AgentRunner:
             )
             return None
 
-        # Aggregate metrics into the session state. ``run_chat`` does not
-        # currently surface token counts, so we credit zero — the field is
-        # still updated so the TokenMeter chip shows turn counts.
+        # Aggregate metrics into the session state (C1).
+        # ``run_chat`` now reports tokens_in / tokens_out / cost_usd off the
+        # provider response (Ollama prompt_eval_count + eval_count, OpenAI
+        # streaming usage, Anthropic final_message.usage, Gemini
+        # usage_metadata) with a 4-chars-per-token fallback when the SDK
+        # omits them. The TokenMeter chip therefore shows real numbers
+        # instead of staying pinned at zero.
+        tokens_in = int(getattr(result, "tokens_in", 0) or 0) if result is not None else 0
+        tokens_out = int(getattr(result, "tokens_out", 0) or 0) if result is not None else 0
+        cost_usd = float(getattr(result, "cost_usd", 0.0) or 0.0) if result is not None else 0.0
         self._state.credit(
             profile_id=(profile.id if profile is not None else self.profile_id or ""),
-            tokens_in=0,
-            tokens_out=0,
-            cost_usd=0.0,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
             tool_calls=0,
         )
         self._state.elapsed_minutes = round((time.time() - self._started_at) / 60.0, 2)
@@ -397,3 +411,24 @@ class AgentRunner:
             return _v("specsmith")
         except Exception:  # noqa: BLE001
             return "0.0.0"
+
+    def _seal_profile_pin(self, profile_id: str) -> None:
+        """Append a TraceVault decision seal recording the ``/agent`` pin (G4).
+
+        Wrapped in best-effort try/except so an unwriteable
+        ``.specsmith/trace.jsonl`` (read-only fs, missing project root, etc.)
+        never breaks the chat loop. The seal type is ``decision`` because
+        a profile pin is an explicit governance choice the user made.
+        """
+        try:
+            from specsmith.trace import SealType, TraceVault
+
+            vault = TraceVault(Path(self.project_dir))
+            vault.seal(
+                seal_type=SealType.DECISION,
+                description=f"agent profile pinned via /agent: {profile_id}",
+                author="runner",
+                artifact_ids=[f"profile:{profile_id}"],
+            )
+        except Exception:  # noqa: BLE001 — trace sealing is best-effort
+            return

--- a/src/specsmith/cli.py
+++ b/src/specsmith/cli.py
@@ -4344,6 +4344,31 @@ def phase_next(project_dir: str, force: bool) -> None:
         for cmd in next_phase.commands:
             console.print(f"    {cmd}")
 
+    # G3: keep the agents routing table aligned with the active phase.
+    # We pin a synthetic ``phase:active`` route so the runner can flip the
+    # whole session to the new phase’s preferred profile without the user
+    # having to run `specsmith agents route set` themselves.
+    try:
+        from specsmith.agent.profiles import ProfileStore
+
+        agents_store = ProfileStore.load()
+        if agents_store.profiles:
+            phase_key_target = f"phase:{phase.next_phase}"
+            target_id = agents_store.routes.get(phase_key_target) or (
+                agents_store.default_profile_id
+            )
+            if target_id and agents_store._index(target_id) is not None:
+                agents_store.set_route("phase:active", target_id)
+                # Make sure the canonical phase:<key> route is present too;
+                # adding a sensible default lets a fresh project route
+                # immediately on the very first ``phase next``.
+                if phase_key_target not in agents_store.routes:
+                    agents_store.set_route(phase_key_target, target_id)
+                agents_store.save()
+                console.print(f"  [dim]\u21bb agents route phase:active \u2192 {target_id}[/dim]")
+    except Exception:  # noqa: BLE001 — routing is opportunistic; never block phase advance
+        pass
+
 
 @phase_group.command(name="status")
 @click.option("--project-dir", type=click.Path(exists=True), default=".")
@@ -6836,29 +6861,46 @@ def agents_group() -> None:
 
 @agents_group.command(name="list")
 @click.option("--project-dir", type=click.Path(exists=True), default=".")
+@click.option(
+    "--capability",
+    "capability",
+    default="",
+    help="Filter profiles whose capabilities list includes this value (G2).",
+)
 @click.option("--json", "as_json", is_flag=True, default=False)
-def agents_list(project_dir: str, as_json: bool) -> None:
+def agents_list(project_dir: str, capability: str, as_json: bool) -> None:
     """List every registered agent profile."""
     import json as _json
 
     from specsmith.agent.profiles import ProfileStore
 
     store = ProfileStore.load_for_project(project_dir)
+    profiles = (
+        store.filter_by_capability(capability) if capability.strip() else list(store.profiles)
+    )
     payload = {
         "default_profile_id": store.default_profile_id,
-        "profiles": [p.to_dict() for p in store.profiles],
+        "profiles": [p.to_dict() for p in profiles],
         "routes": dict(store.routes),
     }
+    if capability.strip():
+        payload["capability_filter"] = capability.strip()
     if as_json:
         click.echo(_json.dumps(payload, indent=2))
         return
-    if not store.profiles:
-        console.print(
-            "[dim]No agent profiles registered. "
-            "Run `specsmith agents preset apply default` to install the recommended set.[/dim]"
-        )
+    if not profiles:
+        if capability.strip():
+            console.print(
+                f"[dim]No profiles advertise capability {capability!r}.[/dim]",
+            )
+        else:
+            console.print(
+                "[dim]No agent profiles registered. "
+                "Run `specsmith agents preset apply default` to install "
+                "the recommended set.[/dim]",
+            )
         return
-    for p in store.profiles:
+    for p in profiles:
         marker = "*" if p.id == store.default_profile_id else " "
         chain = " \u2192 ".join(p.fallback_chain) if p.fallback_chain else "(no fallback)"
         endpoint = f" endpoint={p.endpoint_id}" if p.endpoint_id else ""
@@ -6909,6 +6951,11 @@ def agents_add(
         fallback_chain=list(fallback_chain),
     )
     store = ProfileStore.load()
+    # G1 diversity guard — warn on same-family coder/reviewer pairings *before*
+    # we touch the store so the user can still bail out by Ctrl+C-ing the next
+    # invocation. The warnings are non-fatal: governance still saves the
+    # profile, but we surface the cross-check risk so it's a deliberate choice.
+    diversity = store.diversity_warnings(candidate=profile)
     try:
         store.add(profile, replace=replace)
     except ProfileError as exc:
@@ -6918,11 +6965,18 @@ def agents_add(
         store.set_default(profile.id)
     store.save()
     if as_json:
-        click.echo(_json.dumps({"profile": profile.to_dict()}, indent=2))
+        click.echo(
+            _json.dumps(
+                {"profile": profile.to_dict(), "diversity_warnings": diversity},
+                indent=2,
+            )
+        )
         return
     console.print(f"[green]\u2713[/green] saved profile [bold]{profile.id}[/bold]")
     if store.default_profile_id == profile.id:
         console.print("  [dim]marked as default.[/dim]")
+    for warning in diversity:
+        console.print(f"  [yellow]\u26a0[/yellow] {warning}")
 
 
 @agents_group.command(name="remove")

--- a/tests/test_chat_runner_openai_compat.py
+++ b/tests/test_chat_runner_openai_compat.py
@@ -107,7 +107,10 @@ def test_openai_compat_streams_tokens(fake_chat_server: int) -> None:
         base_url=f"http://127.0.0.1:{port}/v1",
         default_model="fake-model",
     )
-    text = _run_openai_compat(
+    # C1: drivers now return ``(text, usage)`` so the runner can credit
+    # tokens against the AgentState. The legacy contract returned just
+    # ``text``; tests are unpacked here to match.
+    text, _usage = _run_openai_compat(
         [{"role": "user", "content": "hello"}], emitter, "block-1", endpoint=endpoint
     )
     assert text is not None
@@ -126,7 +129,7 @@ def test_openai_compat_returns_none_without_default_model(fake_chat_server: int)
         base_url=f"http://127.0.0.1:{port}/v1",
         default_model="",
     )
-    text = _run_openai_compat(
+    text, _usage = _run_openai_compat(
         [{"role": "user", "content": "hi"}], emitter, "block-1", endpoint=endpoint
     )
     assert text is None
@@ -143,7 +146,7 @@ def test_openai_compat_returns_none_when_unauthorised(fake_chat_server: int) -> 
         default_model="fake-model",
         auth=EndpointAuth(kind="bearer-inline", token="wrong-token"),
     )
-    text = _run_openai_compat(
+    text, _usage = _run_openai_compat(
         [{"role": "user", "content": "hi"}], emitter, "block-1", endpoint=endpoint
     )
     assert text is None


### PR DESCRIPTION
# 0.10.1 follow-up sweep — diversity / capabilities / phase routing / trace seal / token threading + docs

Closes the remaining G1-G4, C1, and H1-H4 todos from the 0.10 multi-agent sprint plan.

## What landed

### G1 — Diversity guard on `agents add`
`ProfileStore.diversity_warnings` walks the profile population and warns
when the reviewer (or architect) shares a provider family with the
coder. New `PROVIDER_FAMILIES` table groups OpenAI-family endpoints
(`openai-compat`, `azure-openai`) and Ollama-family backends
(`llamacpp`, `vllm`, `lmstudio`) so a self-hosted vLLM coder + Ollama
reviewer is correctly flagged as same-family. The CLI prints yellow
warnings (non-fatal) and the `--json` output now includes
`diversity_warnings`.

### G2 — Capability filter
`ProfileStore.filter_by_capability(capability)` plus a new
`specsmith agents list --capability code-review --json` flag. The
extension counterpart (`AgentsClient.filterAgentsByCapability`) ships
in the matching specsmith-vscode PR.

### G3 — `phase next` auto-routes
Advancing the AEE phase now pins a synthetic `phase:active` route to
the new phase's preferred profile (and seeds the canonical
`phase:<key>` entry on first advance). The runner can flip the whole
session by listening for one activity instead of teaching the user
seven `agents route set` commands.

### G4 — TraceVault seal on `/agent`
In-chat `/agent <id>` writes a `decision` seal chained into
`.specsmith/trace.jsonl` so every per-turn profile pin is auditable.
Best-effort: a read-only filesystem / missing project root must never
break the chat loop.

### C1 — Token threading
Each provider driver now returns `(text, _UsageDelta)` and surfaces
real token counts:
* Ollama — `prompt_eval_count` + `eval_count` from the final `done` message
* Anthropic — `final_message.usage.input_tokens` / `output_tokens`
* OpenAI — `stream_options.include_usage` makes the final SSE chunk carry the usage block
* Gemini — `usage_metadata.prompt_token_count` / `candidates_token_count`

When the SDK omits usage, a 4-chars/token heuristic fills in so the
TokenMeter chip is never zero. Counts flow through
`ChatRunResult.tokens_in/out/cost_usd` into `AgentState.credit()` and
the per-profile `by_profile` bucket.

### H1-H4 — Docs
* `docs/site/agents.md` — preset → route → per-session → BYOE walkthrough
* `docs/site/quickstart.md` — reproduction script + GIF placeholder
* `docs/site/vscode-extension.md` — eight new commands documented (sister-PR scope)
* README — multi-agent + BYOE elevator pitch up top

## Verification

* `ruff check src/ tests/` — All checks passed!
* `ruff format --check src/ tests/` — 148 files already formatted
* `pytest -q` — **448 passed, 1 skipped**
* `python -m specsmith.cli api-surface | diff - tests/fixtures/api_surface.json` — clean (no surface drift)

## Out of scope / follow-up

* `A5` release tags — landed once this PR + the matching specsmith-vscode#? PR merge
* Marketplace publish — separate manual step gated on `VSCE_PAT`
