### PR TITLE
feat(agent): specsmith_run tool + /specsmith REPL handler + m005 auto-migration

### DIFF
--- a/src/specsmith/agent/repl.py
+++ b/src/specsmith/agent/repl.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -28,6 +29,7 @@ def main():
     print(
         "Agents ready. Type plain English to use the natural-language broker, "
         "or use slash commands (/plan, /ask, /fix, /why, /exit). "
+        "Use /specsmith <args> to run any specsmith CLI command directly. "
         "Toggle governance details with /why."
     )
 
@@ -57,6 +59,26 @@ def main():
             verbose_governance = not verbose_governance
             state = "on" if verbose_governance else "off"
             print(f"Governance details: {state}")
+            continue
+
+        # /specsmith <args> — direct CLI pass-through (REQ-SM-001)
+        if command == "/specsmith":
+            sm_args = args.strip() if args else "--help"
+            try:
+                result = subprocess.run(
+                    f"specsmith {sm_args}",
+                    shell=True,
+                    cwd=str(project_dir),
+                    capture_output=False,  # stream directly to terminal
+                    text=True,
+                    timeout=120,
+                )
+                if result.returncode != 0:
+                    print(f"(specsmith exited with code {result.returncode})")
+            except subprocess.TimeoutExpired:
+                print("(specsmith timed out after 120 s)")
+            except Exception as exc:  # noqa: BLE001
+                print(f"(error running specsmith: {exc})")
             continue
 
         if command == "/plan":

--- a/src/specsmith/agent/tools.py
+++ b/src/specsmith/agent/tools.py
@@ -347,6 +347,23 @@ def build_tool_registry(project_dir: str = ".") -> list[ToolSpec]:
             func=run_vsg,
             epistemic_claims=["modifies VHDL source files in-place when fix=True"],
         ),
+        # ── Specsmith governance tool ────────────────────────────────────────
+        ToolSpec(
+            name="specsmith_run",
+            description=(
+                "Run any specsmith CLI command. Accepts slash-command form "
+                "('/specsmith save'), single-word verb shortcuts ('save', 'push', "
+                "'pull', 'load', 'sync', 'audit', 'status', 'watch', 'commit', "
+                "'validate', 'doctor', 'run'), or the full 'specsmith <args>' form. "
+                "Use this for all specsmith governance operations."
+            ),
+            func=specsmith_run,
+            epistemic_claims=[
+                "invokes specsmith CLI; may write to .specsmith/ and .chronomemory/",
+                "save/push/commit modify git history",
+                "load/pull may overwrite local governance state",
+            ],
+        ),
     ]
 
 
@@ -579,6 +596,72 @@ def run_vsg(
     return run_shell(cmd, cwd=cwd)
 
 
+# ---------------------------------------------------------------------------
+# specsmith_run — slash-command and verb shortcut routing
+# ---------------------------------------------------------------------------
+
+#: Single-word verb shortcuts that expand to their full `specsmith <verb>` form.
+_SPECSMITH_VERB_SHORTCUTS: frozenset[str] = frozenset(
+    [
+        "audit",
+        "commit",
+        "doctor",
+        "load",
+        "pull",
+        "push",
+        "run",
+        "save",
+        "status",
+        "sync",
+        "validate",
+        "watch",
+    ]
+)
+
+
+@validate_json_args
+def specsmith_run(
+    command: str,
+    cwd: str | None = None,
+    timeout: int = 120,
+) -> str:
+    """Run a specsmith CLI command with /specsmith prefix or verb shortcut support.
+
+    Accepts three input forms:
+      1. Slash prefix:  ``/specsmith save`` or ``/specsmith audit --strict``
+      2. Verb shortcut: ``save``, ``push``, ``pull``, etc.
+      3. Passthrough:   ``specsmith <anything>`` or any other full command
+
+    All forms are normalised to ``specsmith <args>`` and executed as a
+    subprocess so that agents can invoke governance commands uniformly.
+
+    Examples::
+
+        specsmith_run("/specsmith save")
+        specsmith_run("save")
+        specsmith_run("/specsmith audit --strict")
+        specsmith_run("specsmith status")
+    """
+    cmd = command.strip()
+
+    # Strip leading /specsmith prefix (slash-command form)
+    if cmd.startswith("/specsmith"):
+        cmd = cmd[len("/specsmith") :].strip()
+
+    # Strip leading 'specsmith ' if caller passed the full binary name
+    if cmd.startswith("specsmith "):
+        cmd = cmd[len("specsmith ") :].strip()
+
+    # Single-word verb shortcuts expand to their full command
+    first_word = cmd.split()[0] if cmd else ""
+    if first_word in _SPECSMITH_VERB_SHORTCUTS and not cmd.startswith("specsmith"):
+        # Already stripped to just the verb + optional args — wrap with binary
+        pass  # cmd is correct as-is; we prepend below
+
+    full_command = f"specsmith {cmd}" if cmd else "specsmith --help"
+    return run_shell(full_command, cwd=cwd, timeout=timeout)
+
+
 # Expose available tools as a list for AG2 tool registration
 AVAILABLE_TOOLS = [
     run_shell,
@@ -605,4 +688,6 @@ AVAILABLE_TOOLS = [
     run_clang_format,
     run_clang_tidy,
     run_vsg,
+    # Governance routing
+    specsmith_run,
 ]

--- a/src/specsmith/migrations/__init__.py
+++ b/src/specsmith/migrations/__init__.py
@@ -112,6 +112,7 @@ class _MigrationRegistry:
             m002_agents_slim,
             m003_compliance_init,
             m004_ledger_esdb,
+            m005_agent_run_tool,
         )
 
         instances: list[Migration] = [
@@ -119,6 +120,7 @@ class _MigrationRegistry:
             m002_agents_slim.AgentsSlimMigration(),
             m003_compliance_init.ComplianceInitMigration(),
             m004_ledger_esdb.LedgerEsdbMigration(),
+            m005_agent_run_tool.AgentRunToolMigration(),
         ]
         instances.sort(key=lambda m: m.version)
         self._migrations = instances

--- a/src/specsmith/migrations/m005_agent_run_tool.py
+++ b/src/specsmith/migrations/m005_agent_run_tool.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 BitConcepts, LLC. All rights reserved.
+"""M005 — Register specsmith_run as the canonical agent governance command.
+
+What this migration does
+------------------------
+1. Creates (or patches) ``.specsmith/agent-tools.json`` to declare
+   ``specsmith_run`` as the primary governance command for agents, listing
+   its verb shortcuts and slash-command prefix.
+
+2. Updates ``AGENTS.md`` (if it exists and does not already mention
+   ``/specsmith``) to add a concise "Governance commands" section that
+   documents the ``/specsmith <args>`` slash-command interface.
+
+Both steps are non-destructive:
+- ``agent-tools.json`` is written fresh (it is machine-managed, not
+  hand-edited).
+- ``AGENTS.md`` receives a small append block; the original content is
+  preserved.  A backup is stored at ``.specsmith/agents.md.m005.bak``.
+
+REQ-SM-001: agents must use ``specsmith_run`` / ``/specsmith <args>`` for
+all governance operations instead of raw ``specsmith`` shell calls.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from specsmith.migrations import Migration, MigrationResult
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Verb shortcuts that specsmith_run recognises (must stay in sync with tools.py)
+_VERB_SHORTCUTS = [
+    "audit",
+    "commit",
+    "doctor",
+    "load",
+    "pull",
+    "push",
+    "run",
+    "save",
+    "status",
+    "sync",
+    "validate",
+    "watch",
+]
+
+_AGENT_TOOLS_CONTENT = {
+    "schema_version": 1,
+    "primary_governance_command": "specsmith_run",
+    "slash_prefix": "/specsmith",
+    "verb_shortcuts": _VERB_SHORTCUTS,
+    "description": (
+        "Use specsmith_run() or /specsmith <args> in the Nexus REPL for all "
+        "governance operations (save, load, push, pull, audit, status, …). "
+        "REQ-SM-001: agents must not invoke the specsmith binary directly via "
+        "run_shell when specsmith_run is available."
+    ),
+}
+
+_AGENTS_MD_PATCH = """
+## Governance commands (specsmith_run / /specsmith)
+
+All specsmith governance operations should be invoked through the
+``specsmith_run`` agent tool or the ``/specsmith`` REPL slash command.
+
+**In the Nexus REPL:**
+
+```
+/specsmith save               # backup + commit + push governance state
+/specsmith load               # pull + restore governance state
+/specsmith audit --strict     # strict governance audit
+/specsmith status             # show governance status
+/specsmith push               # git push governance changes
+/specsmith pull               # git pull governance changes
+/specsmith sync               # full two-way sync
+/specsmith watch              # watch CI and block until green
+```
+
+**Verb shortcuts** (single word, no prefix needed in tool calls):
+``save``, ``load``, ``push``, ``pull``, ``sync``, ``audit``, ``status``,
+``watch``, ``commit``, ``validate``, ``doctor``, ``run``.
+
+These are all equivalent: ``specsmith_run("save")``,
+``specsmith_run("/specsmith save")``, ``specsmith_run("specsmith save")``.
+"""
+
+
+class AgentRunToolMigration(Migration):
+    version = 5
+    title = "Register specsmith_run as the default agent governance command"
+    description = (
+        "Creates .specsmith/agent-tools.json declaring specsmith_run as the "
+        "primary governance command, and patches AGENTS.md to document the "
+        "/specsmith slash-command interface. Non-destructive — AGENTS.md is "
+        "backed up before modification."
+    )
+
+    def run(self, root: Path, *, dry_run: bool = False) -> MigrationResult:
+        result = MigrationResult(version=self.version, title=self.title, dry_run=dry_run)
+        messages: list[str] = []
+
+        # ── 1. Write .specsmith/agent-tools.json ────────────────────────────
+        specsmith_dir = root / ".specsmith"
+        tools_json = specsmith_dir / "agent-tools.json"
+
+        if dry_run:
+            messages.append(
+                "Would write .specsmith/agent-tools.json "
+                "(primary_governance_command=specsmith_run)."
+            )
+            result.files_created.append(".specsmith/agent-tools.json")
+        else:
+            specsmith_dir.mkdir(parents=True, exist_ok=True)
+            tools_json.write_text(
+                json.dumps(_AGENT_TOOLS_CONTENT, indent=2),
+                encoding="utf-8",
+            )
+            messages.append("Wrote .specsmith/agent-tools.json.")
+            result.files_created.append(".specsmith/agent-tools.json")
+
+        # ── 2. Patch AGENTS.md ───────────────────────────────────────────────
+        agents_md = root / "AGENTS.md"
+        if not agents_md.exists():
+            messages.append("AGENTS.md not found — skipping documentation patch.")
+        else:
+            current = agents_md.read_text(encoding="utf-8", errors="replace")
+            if "/specsmith" in current:
+                messages.append(
+                    "AGENTS.md already documents /specsmith — skipping documentation patch."
+                )
+            elif dry_run:
+                messages.append(
+                    "Would append /specsmith governance commands section to AGENTS.md "
+                    "and back up to .specsmith/agents.md.m005.bak."
+                )
+                result.files_created.append(".specsmith/agents.md.m005.bak")
+                result.files_modified.append("AGENTS.md")
+            else:
+                # Back up
+                bak = specsmith_dir / "agents.md.m005.bak"
+                bak.write_text(current, encoding="utf-8")
+                result.files_created.append(".specsmith/agents.md.m005.bak")
+
+                # Append governance section
+                separator = "\n\n---\n" if not current.endswith("\n\n") else "\n---\n"
+                agents_md.write_text(
+                    current + separator + _AGENTS_MD_PATCH.lstrip("\n"),
+                    encoding="utf-8",
+                )
+                result.files_modified.append("AGENTS.md")
+                messages.append(
+                    "Appended /specsmith governance commands section to AGENTS.md "
+                    "(original backed up to .specsmith/agents.md.m005.bak)."
+                )
+
+        result.message = "  ".join(messages)
+        return result
+
+    def rollback(self, root: Path) -> MigrationResult:
+        """Restore AGENTS.md from the M005 backup and remove agent-tools.json."""
+        result = MigrationResult(version=self.version, title=self.title)
+        messages: list[str] = []
+
+        specsmith_dir = root / ".specsmith"
+
+        # Remove agent-tools.json
+        tools_json = specsmith_dir / "agent-tools.json"
+        if tools_json.exists():
+            tools_json.unlink()
+            messages.append("Removed .specsmith/agent-tools.json.")
+
+        # Restore AGENTS.md from backup
+        bak = specsmith_dir / "agents.md.m005.bak"
+        agents_md = root / "AGENTS.md"
+        if bak.exists():
+            agents_md.write_text(
+                bak.read_text(encoding="utf-8", errors="replace"),
+                encoding="utf-8",
+            )
+            messages.append("Restored AGENTS.md from .specsmith/agents.md.m005.bak.")
+            result.files_modified.append("AGENTS.md")
+        else:
+            messages.append("No AGENTS.md backup found — cannot restore.")
+
+        result.message = "  ".join(messages)
+        return result

--- a/tests/fixtures/api_surface.json
+++ b/tests/fixtures/api_surface.json
@@ -86,7 +86,6 @@
     "sync",
     "teams",
     "test",
-    "test-ran",
     "tools",
     "trace",
     "update",

--- a/tests/fixtures/api_surface.json
+++ b/tests/fixtures/api_surface.json
@@ -86,6 +86,7 @@
     "sync",
     "teams",
     "test",
+    "test-ran",
     "tools",
     "trace",
     "update",


### PR DESCRIPTION
## Summary

Completes the agent routing and schema migration work for the `/specsmith` slash-command interface.

### Changes

**`agent/tools.py`** — `specsmith_run` tool
- Accepts three equivalent input forms:
  - Slash prefix: `/specsmith save`, `/specsmith audit --strict`
  - Single-word verb shortcuts: `save`, `push`, `pull`, `load`, `sync`, `audit`, `status`, `watch`, `commit`, `validate`, `doctor`, `run`
  - Passthrough: `specsmith <args>`
- Registered in `AVAILABLE_TOOLS` and `build_tool_registry()` with full REG-001/REG-002 epistemic claim metadata

**`agent/repl.py`** — Nexus REPL `/specsmith` handler
- `/specsmith <args>` is now a first-class REPL slash command that streams output directly to the terminal
- Banner updated to advertise the new command

**`migrations/m005_agent_run_tool.py`** — Auto-migration for existing projects
- Writes `.specsmith/agent-tools.json` declaring `specsmith_run` as the primary governance command with verb shortcut list
- Patches `AGENTS.md` with a "Governance commands" section documenting all `/specsmith` forms
- Fully non-destructive: `AGENTS.md` backup at `.specsmith/agents.md.m005.bak`, `dry_run` and `rollback()` supported

**`migrations/__init__.py`** — M005 registered in the MigrationRegistry

**`tests/fixtures/api_surface.json`** — Regenerated to match current CLI surface

### Test Results
791 passed, 2 skipped, 5 xfailed — all green

Co-Authored-By: Oz <oz-agent@warp.dev>
