### PR TITLE
docs: add integration, documentation, and compliance issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/compliance_question.md
+++ b/.github/ISSUE_TEMPLATE/compliance_question.md
@@ -1,0 +1,28 @@
+---
+name: Compliance / Governance Question
+about: Ask about compliance, governance, or policy matters
+title: "compliance: "
+labels: compliance
+---
+
+## Topic
+Which compliance or governance area does this question relate to?
+
+- [ ] Code licensing / IP
+- [ ] Dependency compliance (SBOM, provenance)
+- [ ] Security policy / vulnerability reporting
+- [ ] Project governance / decision-making
+- [ ] Contributor agreement / DCO
+- [ ] Export control / regulatory
+- [ ] Other
+
+## Question
+Clearly state your compliance or governance question.
+
+## Context
+Any relevant background, regulations, or policies you're working with.
+
+## Additional Information
+Links, references, or related discussions.
+
+> **Security vulnerability?** Do not file publicly — follow the instructions in [SECURITY.md](https://github.com/layer1labs/specsmith/blob/main/SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Documentation
     url: https://specsmith.readthedocs.io
     about: Check the docs before filing an issue
+  - name: Security Report
+    url: https://github.com/layer1labs/specsmith/blob/main/SECURITY.md
+    about: Report a security vulnerability (private disclosure)

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,0 +1,26 @@
+---
+name: Documentation Issue
+about: Report missing, unclear, or incorrect documentation
+title: "docs: "
+labels: documentation
+---
+
+## Documentation Location
+- File or URL:
+- Section (if applicable):
+
+## Issue Type
+- [ ] Missing documentation
+- [ ] Unclear or confusing explanation
+- [ ] Incorrect information
+- [ ] Outdated content
+- [ ] Typo or formatting issue
+
+## Description
+Describe the documentation issue in detail.
+
+## Suggested Improvement
+What should the documentation say instead?
+
+## Additional Context
+Any related issues, PRs, or references.

--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -1,0 +1,23 @@
+---
+name: Integration Request
+about: Request support for a new tool, service, or platform integration
+title: "integration: "
+labels: integration
+---
+
+## Integration Target
+Name and URL of the tool/service/platform you'd like specsmith to integrate with.
+
+## Use Case
+Describe the workflow or scenario where this integration would be used.
+
+## Expected Behavior
+What should the integration do? Include example commands or config if possible.
+
+## API / Interface Details
+- API documentation link:
+- Authentication method (if known):
+- SDK availability (Python preferred):
+
+## Additional Context
+Any other details, alternatives considered, or related issues.


### PR DESCRIPTION
## Problem
The issue template chooser was missing templates for integration requests, documentation issues, and compliance/governance questions. The config.yml also lacked a security report contact link.

## Solution
Added three new issue templates:
- **integration_request.md** — for requesting new tool/service/platform integrations
- **documentation_issue.md** — for reporting missing, unclear, or incorrect documentation
- **compliance_question.md** — for compliance, governance, and policy questions

Also updated **config.yml** with a security report contact link pointing to SECURITY.md for private vulnerability disclosure.

Closes #236