### PR TITLE
release: v0.16.2 — bugfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ consolidated into the next published release.
 
 ---
 
+## [0.16.2] - 2026-06-23
+
+### Fixed
+
+- **Issue #257 — `audit industrial_artifacts` false positive on Windows** —
+  `check_industrial_artifacts` now handles both plain-string entries
+  (`- path/to/file.eds`) and dict entries (`- path: ..., device: ...`) in
+  `canopen_eds`. Previously only dict entries were matched, so string-format
+  declarations always appeared undeclared regardless of OS.
+- **6 CodeQL alerts resolved (all alerts → 0)**:
+  - `src/specsmith/sync.py` — `...` replaced with `pass` in `_MigratableStore`
+    Protocol stub methods (`py/ineffectual-statement` #192 #193).
+  - `scripts/govern_bench/harness.py` — removed dead variable initializations
+    before an if/elif/else block that always assigns all four variables
+    (`py/multiple-definition` #196).
+  - `scripts/govern_bench/projects/` — excluded from CodeQL via
+    `.github/codeql/codeql-config.yml`; this directory contains intentional
+    benchmark bugs (mutable default argument = the T2 task agents must fix)
+    (`py/modification-of-default-value` #195, `py/unused-global-variable` #197,
+    `py/import-and-import-from` #194).
+- **Pre-existing broken test fixed** — `test_industrial_artifacts_normalizes_
+  windows_declared_paths` was writing double-backslash to YAML which normalised
+  to `//` and never matched the found path; corrected to a single backslash.
+
+### Added
+
+- Two regression tests for #257: plain-string-only entries and mixed
+  string+dict entries in `canopen_eds`.
+
+---
+
 ## [0.16.1] - 2026-06-23
 
 ### Added
@@ -441,7 +472,8 @@ See git history for per-commit details on intermediate versions.
 
 ---
 
-[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.16.2...HEAD
+[0.16.2]: https://github.com/layer1labs/specsmith/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/layer1labs/specsmith/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/layer1labs/specsmith/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/layer1labs/specsmith/compare/v0.15.2...v0.15.3

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ We ran a [multi-condition benchmark](https://specsmith.readthedocs.io/en/stable/
 
 See the [full benchmark report](https://specsmith.readthedocs.io/en/stable/efficiency-benchmark/) and [model comparison (gpt-4o-mini vs gpt-5.5)](https://specsmith.readthedocs.io/en/stable/model-comparison/).
 
+**v0.16.2** — bugfix release: resolved all 6 open CodeQL alerts (Protocol stub `py/ineffectual-statement`, dead-init `py/multiple-definition`; benchmark demo project excluded from scan); fixed `audit industrial_artifacts` false positive on Windows when `canopen_eds` entries are plain strings instead of dicts (closes #257).
+
 **v0.16.1** — governance efficiency benchmark suite (12 conditions, 3 tasks, gpt-4o-mini + gpt-5.5 comparison); cross-model comparison report; real OpenAI agent harness; CI matrix job. Also includes the v0.16.0 stabilisation milestone: 20+ CLI commands, ESDB SQLite backend, chronomemory 0.2.0, Python 3.10–3.13 × Ubuntu + Windows green, 1 607 tests passing.
 
 specsmith ships a full compliance and auditability layer aligned to the EU AI Act (2024/1689) and the NIST AI Risk Management Framework 1.0. Every agent action is cryptographically sealed, every AI-generated output is disclosed, context windows are GPU-aware, and compliance settings are configurable per-session and per-project.
@@ -397,7 +399,7 @@ Every preflight response includes a mandatory `ai_disclosure` block:
     "governance_gated": true,
     "provider": "ollama",
     "model": "qwen2.5:14b",
-    "spec_version": "0.16.1"
+    "spec_version": "0.16.2"
   }
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specsmith"
-version = "0.16.1"
+version = "0.16.2"
 description = "AEE governance toolkit for AI-assisted development — session preflight gates, multi-agent dispatch, requirements↔test traceability, ESDB persistence, MCP server, and skills for Warp, Cursor, Claude Code, Copilot, Windsurf, and Aider."
 readme = "README.md"
 license = "MIT"

--- a/src/specsmith/__init__.py
+++ b/src/specsmith/__init__.py
@@ -8,4 +8,4 @@ from importlib.metadata import version as _pkg_version
 try:
     __version__: str = _pkg_version("specsmith")
 except PackageNotFoundError:  # running from source without install
-    __version__ = "0.16.1"  # fallback: keep in sync with pyproject.toml
+    __version__ = "0.16.2"  # fallback: keep in sync with pyproject.toml


### PR DESCRIPTION
Version bump and docs for v0.16.2 bugfix release.

See CHANGELOG.md for full details. Merging this + tagging \0.16.2\ on main will trigger \elease.yml\ which publishes to PyPI, creates the GitHub release, and triggers RTD.

Co-Authored-By: Oz <oz-agent@warp.dev>