### PR TITLE
release: prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Only versions published to PyPI are listed. Intermediate development versions are
 consolidated into the next published release.
 
-## [0.21.0] - 2026-07-06
-### Added
-- CPU fallback for local model detection (REQ-445) - When no GPU is detected, Specsmith now falls back to a minimal CPU-safe model instead of returning no recommendation
-### Changed
-- Markdown governance mode deprecated - Running `specsmith sync` in markdown mode now emits a DeprecationWarning and auto-triggers m007 migration
-- Auditor YAML dir checks are mode-aware - The yaml-requirements-dir and yaml-tests-dir audit checks now only fail for projects in YAML-first mode
-- `specsmith architect` is now a group command - `specsmith architect` (without a subcommand) retains its original behavior, new subcommands `interview`, `gap`, and `update` are added
-- Req-test coverage check uses testcases.json - In YAML-first mode, the auditor now also uses `requirement_id` from `testcases.json` and `test_ids` from `requirements.json` to determine test coverage
-### Fixed
-- Issue #263 - `esdb status --json` emitted bare "Aborted!" on Windows when Click's _winconsole stream detection raised a KeyboardInterrupt
-- Issue #264 - `specsmith save` false positive dirty-tree warning - Post-commit _get_dirty_files() check now correctly ignores untracked files
-- CI matrix: Python 3.10-3.13 fully green - _read_project_name in quality_report.py now uses tomllib → tomli → regex fallback chain so pyproject.toml is parsed correctly on Python 3.10
----
 ## [Unreleased]
 
 ## [0.22.0] - 2026-07-10
 ### Added
+- CPU fallback for local model detection (REQ-445) - When no GPU is detected,
+  Specsmith now falls back to a minimal CPU-safe model instead of returning no
+  recommendation.
 - Epistemic chat handoffs (REQ-446) - Tiered context compaction now creates
   extractive, provenance-linked ESDB handoffs that Zoo-Code and other agents can export.
 - Mergeable session event log (REQ-447) - `.chronomemory/session-events.jsonl`
@@ -932,7 +922,8 @@ See git history for per-commit details on intermediate versions.
 
 ---
 
-[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/layer1labs/specsmith/compare/v0.20.1...v0.22.0
 [0.20.1]: https://github.com/layer1labs/specsmith/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/layer1labs/specsmith/compare/v0.19.2...v0.20.0
 [0.17.1]: https://github.com/layer1labs/specsmith/compare/v0.17.0...v0.17.1

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ To enable development mode, set `enable_development_mode: true` in your project'
 
 See the [full benchmark report](https://specsmith.readthedocs.io/en/stable/efficiency-benchmark/) and [model comparison (gpt-4o-mini vs gpt-5.5)](https://specsmith.readthedocs.io/en/stable/model-comparison/).
 
-**v0.21.0** - CPU fallback for local model detection: When no GPU is detected, Specsmith now falls back to a minimal CPU-safe model instead of returning no recommendation (REQ-445). Also includes all v0.20.0 features.
-
-**v0.20.0** — Native Warp integration: `specsmith integrate warp` scaffolds `.warp/` MCP + launch configs and a Warp-aware `specsmith run` banner (REQ-444). Plus VRAM-aware local model recommendations: `specsmith local-model recommend` prints a per-role lineup (default / fast / harder pass / general) with a `fits`/`tight`/`spills` fit assessment (REQ-445).
+**v0.22.0** - Epistemic chat handoffs preserve source provenance for Zoo-Code and
+other agents, while a mergeable JSONL session-event log keeps collaboration state
+reviewable. This release also adds CPU-safe local-model fallback (REQ-445) and
+stable-release validation before PyPI publishing.
 
 **v0.20.0** — Native Warp integration: `specsmith integrate warp` scaffolds `.warp/` MCP + launch configs and a Warp-aware `specsmith run` banner (REQ-444). Plus VRAM-aware local model recommendations: `specsmith local-model recommend` prints a per-role lineup (default / fast / harder pass / general) with a `fits`/`tight`/`spills` fit assessment (REQ-445).
 

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -1,14 +1,14 @@
 # Compliance Report — specsmith
 
-**Generated:** 2026-07-05
+**Generated:** 2026-07-13
 
 ## Project Summary
 
 - **Name**: specsmith
-- **Type**: CLI tool (Python)
+- **Type**: python
 - **Language**: python
 - **VCS Platform**: github
-- **Spec Version**: 0.20.1
+- **Spec Version**: 0.22.0
 
 ## Verification Tools
 
@@ -21,7 +21,7 @@
 
 ## Audit Summary
 
-- **Passed**: 35
+- **Passed**: 73
 - **Failed**: 0
 - **Fixable**: 0
 - **Status**: Healthy
@@ -49,35 +49,73 @@
 - ✓ rules.yaml contains structured 'rules' entries
 - ✓ session-protocol.yaml valid (m001 content-blob, kind=session-protocol)
 - ✓ verification.yaml valid (m001 content-blob, kind=verification)
-- ✓ All 403 accepted REQ(s) have test coverage
-- ✓ LEDGER.md has 309 lines (within 500 threshold)
+- ✓ All 412 accepted REQ(s) have test coverage
+- ✓ LEDGER.md has 461 lines (within 500 threshold)
 - ✓ 0 open, 0 closed TODOs
-- ✓ AGENTS.md: 191 lines
-- ✓ docs/governance/RULES.md: 243 lines
-- ✓ docs/governance/SESSION-PROTOCOL.md: 80 lines
-- ✓ docs/governance/LIFECYCLE.md: 44 lines
-- ✓ docs/governance/ROLES.md: 30 lines
-- ✓ docs/governance/CONTEXT-BUDGET.md: 62 lines
-- ✓ docs/governance/VERIFICATION.md: 43 lines
-- ✓ docs/governance/DRIFT-METRICS.md: 54 lines
+- ✓ AGENTS.md: 122 lines
+- ✓ docs/governance/RULES.md: 18 lines
+- ✓ docs/governance/SESSION-PROTOCOL.md: 50 lines
+- ✓ docs/governance/LIFECYCLE.md: 28 lines
+- ✓ docs/governance/ROLES.md: 51 lines
+- ✓ docs/governance/CONTEXT-BUDGET.md: 40 lines
+- ✓ docs/governance/VERIFICATION.md: 49 lines
+- ✓ docs/governance/DRIFT-METRICS.md: 44 lines
 - ✓ Phase 🚀 Release: 100% ready
+- ✓ WI-C5A3000C risk=low gates satisfied
+- ✓ WI-424D94E9 risk=low gates satisfied
+- ✓ WI-75940FB5 risk=low gates satisfied
+- ✓ WI-55ED3D3C risk=low gates satisfied
+- ✓ WI-F1579D03 risk=low gates satisfied
+- ✓ WI-3E135E87 risk=low gates satisfied
+- ✓ WI-0A0CBF48 risk=low gates satisfied
+- ✓ WI-D3390673 risk=low gates satisfied
+- ✓ WI-EE91A49E risk=low gates satisfied
+- ✓ WI-75EB75D4 risk=low gates satisfied
+- ✓ WI-AD2B9BF6 risk=low gates satisfied
+- ✓ WI-100A6DB0 risk=low gates satisfied
+- ✓ WI-1FA34EDD risk=low gates satisfied
+- ✓ WI-54FBF673 risk=low gates satisfied
+- ✓ WI-7195E80A risk=low gates satisfied
+- ✓ WI-CCB839B8 risk=low gates satisfied
+- ✓ WI-90F68EC4 risk=low gates satisfied
+- ✓ WI-AD8285B7 risk=low gates satisfied
+- ✓ WI-F9B14D9C risk=low gates satisfied
+- ✓ WI-C4FB242E risk=low gates satisfied
+- ✓ WI-C1B608A9 risk=low gates satisfied
+- ✓ WI-FCA45C63 risk=low gates satisfied
+- ✓ WI-14572445 risk=low gates satisfied
+- ✓ WI-549942F2 risk=low gates satisfied
+- ✓ WI-6484EE02 risk=low gates satisfied
+- ✓ WI-CFC9C82C risk=low gates satisfied
+- ✓ WI-508DEB6C risk=medium gates satisfied
+- ✓ WI-605822F2 risk=low gates satisfied
+- ✓ WI-A210227F risk=low gates satisfied
+- ✓ WI-5A57E6D6 risk=low gates satisfied
+- ✓ WI-940D7073 risk=low gates satisfied
+- ✓ WI-094C4FE3 risk=low gates satisfied
+- ✓ WI-898AEB59 risk=low gates satisfied
+- ✓ WI-B4E3F895 risk=low gates satisfied
+- ✓ WI-1DDA18E0 risk=low gates satisfied
+- ✓ WI-DA14F483 risk=medium gates satisfied
+- ✓ WI-8F467602 risk=medium gates satisfied
+- ✓ WI-5C560143 risk=medium gates satisfied
 
 ## Recent Activity
 
-- `c4c3d8a chore: sync develop to main (v0.20.1 + Warp integration + docs)`
-- `8492ad8 wi_close WI-0CB81412: done`
-- `3668ecf wi_close WI-0CB81412: done`
-- `dca6269 wi_close WI-0CB81412: done`
-- `633373d wi_close WI-0CB81412: done`
-- `2168489 chore(governance): link TEST-051 to release WI-81102448 (v0.20.1)`
-- `38b477b Merge pull request #272 from layer1labs/develop`
-- `86da788 release: v0.20.1`
-- `592f0b5 Merge pull request #271 from layer1labs/develop`
-- `75f8741 docs(readme): correct skill count to 138 and add brief-lang project type`
+- `52c33fd KILL SWITCH ACTIVATED: emergency stop`
+- `da69815 KILL SWITCH ACTIVATED: emergency stop`
+- `46da691 Merge pull request #292 from layer1labs/codex/clear-postmerge-codeql`
+- `05d3e38 fix: clear remaining post-merge CodeQL findings`
+- `eafcd63 Merge pull request #291 from layer1labs/codex/epistemic-release`
+- `76adac6 fix: resolve remaining CodeQL review findings`
+- `cf91bab merge: integrate Zoo/Roo governance configuration`
+- `ec2e978 wi_close WI-094C4FE3: Published archive/feat-zoo-roo-mcp-integration-202`
+- `c1bd591 KILL SWITCH ACTIVATED: emergency stop`
+- `d5ca276 fix: keep generated ESDB state out of saves`
 
 **Contributors:**
-- 655	Tristen Pierson
-- 4	dependabot[bot]
+- 724	Tristen Pierson
+- 5	dependabot[bot]
 - 1	Aqil Aziz
 
 ## AI System Inventory (REG-010)

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -439,3 +439,11 @@
 - **Status**: complete
 - **Epistemic status**: high
 - **Chain hash**: `702e7876aafc9f6b...`
+
+## 2026-07-13T16:07 — KILL SWITCH ACTIVATED: emergency stop
+- **Author**: specsmith-operator
+- **Type**: kill-switch
+- **REQs affected**: REG-005
+- **Status**: complete
+- **Epistemic status**: high
+- **Chain hash**: `07c2f32732b2ca93...`

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -447,3 +447,15 @@
 - **Status**: complete
 - **Epistemic status**: high
 - **Chain hash**: `07c2f32732b2ca93...`
+
+## 2026-07-13T16:45 — wi_close WI-DA14F483: Release-readiness review completed; full validation evidence recorded.
+- **Author**: specsmith
+- **Type**: wi_close
+- **Status**: complete
+- **Chain hash**: `ff9df0399f80ac97...`
+
+## 2026-07-13T16:45 — wi_close WI-8F467602: Release plan clarified and superseded by WI-5C560143.
+- **Author**: specsmith
+- **Type**: wi_close
+- **Status**: complete
+- **Chain hash**: `f558c2338dc69263...`

--- a/docs/SPECSMITH.yml
+++ b/docs/SPECSMITH.yml
@@ -9,7 +9,7 @@ description: |
   through governance, traceability, and automated compliance checking.
 
 type: python
-version: 0.20.1
+version: 0.22.0
 license: MIT
 author: Layer1 Labs
 url: https://github.com/layer1labs/specsmith

--- a/src/specsmith/cli.py
+++ b/src/specsmith/cli.py
@@ -3853,7 +3853,7 @@ def channel_set_cmd(channel: str) -> None:
     if channel == "stable" and is_prerelease_version(__version__):
         raise click.UsageError(
             "Cannot select stable while a prerelease is installed. "
-            f"Install a stable build first: {version_mismatch_remediation('0.21.0')}"
+            f"Install a stable build first: {version_mismatch_remediation('0.22.0')}"
         )
 
     set_persisted_channel(channel)


### PR DESCRIPTION
## Release preparation\n\n- corrects the published-version history and release links for v0.22.0\n- refreshes README, project metadata, compliance evidence, and stable-channel guidance\n- records clean release validation evidence in the governance ledger\n\n## Local validation\n\n- ruff format and lint\n- mypy\n- 2,250 passed, 8 skipped, 5 xfailed\n- mkdocs build --strict\n- pip-audit\n- specsmith audit, validate --strict, and sync --check\n- build plus twine check\n\nCloses the release-readiness documentation discrepancy before tag publication.