### PR TITLE
fix(ci): validate RTD latest deployment source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,32 +190,7 @@ jobs:
     continue-on-error: true
     if: false  # manual trigger only — use rtd-deploy.yml workflow
     steps:
-      - name: Trigger ReadTheDocs stable build
-        env:
-          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+      - name: Manual RTD deployment required
         run: |
-          if [ -z "$RTD_TOKEN" ]; then
-            echo "WARNING: RTD_TOKEN not set — skipping RTD trigger."
-            exit 0
-          fi
-          TAG="${{ github.ref_name }}"
-          echo "Triggering RTD builds for tag ${TAG}..."
-
-          # 1. Trigger the 'stable' version build (auto-tracked from latest tag)
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-            -H "Authorization: Token $RTD_TOKEN" \
-            "https://readthedocs.org/api/v3/projects/specsmith/versions/stable/builds/")
-          echo "RTD stable build trigger: HTTP $STATUS"
-
-          # 2. Point 'latest' at main so it tracks the stable release
-          curl -s -o /dev/null -X PATCH \
-            -H "Authorization: Token $RTD_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d '{"identifier": "main", "active": true}' \
-            "https://readthedocs.org/api/v3/projects/specsmith/versions/latest/"
-
-          # 3. Trigger a fresh 'latest' build (now tracking main)
-          LATEST=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-            -H "Authorization: Token $RTD_TOKEN" \
-            "https://readthedocs.org/api/v3/projects/specsmith/versions/latest/builds/")
-          echo "RTD latest build trigger: HTTP $LATEST"
+          echo "::error::RTD deployment is manual. Use rtd-deploy.yml so project source, version sync, and build results are validated."
+          exit 1

--- a/.github/workflows/rtd-deploy.yml
+++ b/.github/workflows/rtd-deploy.yml
@@ -48,6 +48,27 @@ jobs:
           fi
           echo "RTD_TOKEN present."
 
+      - name: Configure RTD project source
+        if: github.event.inputs.build_stable == 'true' || github.event.inputs.build_latest == 'true'
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          PROJECT_STATUS=$(curl -sS -o /tmp/rtd-project.json -w "%{http_code}" -X PATCH \
+            -H "Authorization: Token $RTD_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"repository":{"url":"https://github.com/layer1labs/specsmith.git","type":"git"},"default_branch":"main","homepage":"https://github.com/layer1labs/specsmith"}' \
+            "https://readthedocs.org/api/v3/projects/specsmith/")
+          echo "RTD project update: HTTP $PROJECT_STATUS"
+          cat /tmp/rtd-project.json
+          [ "$PROJECT_STATUS" = "204" ] || { echo "::error::RTD project update failed."; exit 1; }
+
+          SYNC_STATUS=$(curl -sS -o /tmp/rtd-sync.json -w "%{http_code}" -X POST \
+            -H "Authorization: Token $RTD_TOKEN" \
+            "https://readthedocs.org/api/v3/projects/specsmith/sync-versions/")
+          echo "RTD version sync: HTTP $SYNC_STATUS"
+          cat /tmp/rtd-sync.json
+          [ "$SYNC_STATUS" = "202" ] || { echo "::error::RTD version sync failed."; exit 1; }
+
       - name: Trigger RTD stable build
         if: github.event.inputs.build_stable == 'true'
         env:
@@ -58,19 +79,29 @@ jobs:
             "https://readthedocs.org/api/v3/projects/specsmith/versions/stable/builds/")
           echo "RTD stable build trigger: HTTP $STATUS"
           cat /tmp/rtd-stable.json
-          [ "$STATUS" = "202" ] || { echo "::warning::Unexpected HTTP $STATUS from RTD stable trigger."; }
+          [ "$STATUS" = "202" ] || { echo "::error::RTD stable build trigger failed."; exit 1; }
 
-      - name: Point RTD latest at main
+      - name: Verify RTD latest tracks main
         if: github.event.inputs.build_latest == 'true'
         env:
           RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
         run: |
-          curl -s -o /tmp/rtd-patch.json -X PATCH \
-            -H "Authorization: Token $RTD_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d '{"identifier": "main", "active": true}' \
-            "https://readthedocs.org/api/v3/projects/specsmith/versions/latest/"
-          echo "RTD latest patched to track main."
+          for attempt in {1..12}; do
+            LATEST_STATUS=$(curl -sS -o /tmp/rtd-latest.json -w "%{http_code}" \
+              -H "Authorization: Token $RTD_TOKEN" \
+              "https://readthedocs.org/api/v3/projects/specsmith/versions/latest/")
+            [ "$LATEST_STATUS" = "200" ] || { echo "::error::RTD latest lookup failed with HTTP $LATEST_STATUS."; cat /tmp/rtd-latest.json; exit 1; }
+            LATEST_IDENTIFIER=$(python -c "import json; print(json.load(open('/tmp/rtd-latest.json'))['identifier'])")
+            if [ "$LATEST_IDENTIFIER" = "main" ]; then
+              echo "RTD latest now tracks main."
+              exit 0
+            fi
+            echo "RTD latest is '$LATEST_IDENTIFIER'; waiting for version sync ($attempt/12)."
+            sleep 5
+          done
+          echo "::error::RTD latest did not switch to main after version sync."
+          cat /tmp/rtd-latest.json
+          exit 1
 
       - name: Trigger RTD latest build
         if: github.event.inputs.build_latest == 'true'
@@ -82,7 +113,7 @@ jobs:
             "https://readthedocs.org/api/v3/projects/specsmith/versions/latest/builds/")
           echo "RTD latest build trigger: HTTP $STATUS"
           cat /tmp/rtd-latest.json
-          [ "$STATUS" = "202" ] || { echo "::warning::Unexpected HTTP $STATUS from RTD latest trigger."; }
+          [ "$STATUS" = "202" ] || { echo "::error::RTD latest build trigger failed."; exit 1; }
 
       - name: Summary
         if: always()

--- a/.specsmith/requirements.json
+++ b/.specsmith/requirements.json
@@ -733,7 +733,8 @@
     "source": "specsmith governance",
     "status": "planned",
     "test_ids": [
-      "TEST-067"
+      "TEST-067",
+      "TEST-473"
     ]
   },
   {

--- a/.specsmith/testcases.json
+++ b/.specsmith/testcases.json
@@ -5122,5 +5122,17 @@
     "input": {},
     "expected_behavior": {},
     "confidence": 1.0
+  },
+  {
+    "id": "TEST-473",
+    "version": 1,
+    "title": "RTD deployment workflow configures canonical repository and main latest branch",
+    "description": "Verify the RTD deployment workflow updates the RTD project to layer1labs/specsmith on main, synchronizes versions, and fails on rejected project, version, or build API responses.",
+    "requirement_id": "REQ-067",
+    "type": "unit",
+    "verification_method": "pytest tests/test_rtd_deploy_workflow.py",
+    "input": {},
+    "expected_behavior": {},
+    "confidence": 1.0
   }
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ consolidated into the next published release.
 
 ## [Unreleased]
 
+### Fixed
+- **Read the Docs latest deployment** - The manual RTD workflow now configures the
+  canonical `layer1labs/specsmith` repository and `main` default branch, synchronizes
+  versions, verifies `latest` maps to `main`, and fails on rejected API responses.
+
 ## [0.22.1] - 2026-07-13
 ### Fixed
 - **ESDB license activation in pipx** (#295) - The Ed25519 `cryptography` verifier

--- a/docs/tests/agent.yml
+++ b/docs/tests/agent.yml
@@ -713,3 +713,11 @@
   input: {}
   expected_behavior: {}
   confidence: 1.0
+- id: TEST-473
+  title: RTD deployment workflow configures canonical repository and main latest branch
+  requirement_id: REQ-067
+  type: unit
+  verification_method: pytest tests/test_rtd_deploy_workflow.py
+  description: Verify the RTD deployment workflow updates the RTD project to layer1labs/specsmith
+    on main, synchronizes versions, and fails on rejected project, version, or build
+    API responses.

--- a/tests/test_rtd_deploy_workflow.py
+++ b/tests/test_rtd_deploy_workflow.py
@@ -1,0 +1,19 @@
+"""Regression coverage for the checked Read the Docs deployment workflow."""
+
+from pathlib import Path
+
+
+def test_rtd_deploy_uses_canonical_project_and_main() -> None:
+    """TEST-473: latest must be synchronized from this repository's main branch."""
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "rtd-deploy.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "https://github.com/layer1labs/specsmith.git" in workflow
+    assert '"default_branch":"main"' in workflow
+    assert "projects/specsmith/sync-versions/" in workflow
+    assert '[ "$PROJECT_STATUS" = "204" ]' in workflow
+    assert '[ "$SYNC_STATUS" = "202" ]' in workflow
+    assert "RTD latest now tracks main." in workflow
+    assert "RTD latest did not switch to main after version sync." in workflow
+    assert '[ "$STATUS" = "202" ]' in workflow


### PR DESCRIPTION
Repairs RTD latest deployment after verification showed the project still tracked BitConcepts/specsmith develop. The manual workflow now configures layer1labs/specsmith and main at the project level, syncs versions, verifies latest maps to main, and fails on rejected API calls. Removes the stale disabled duplicate path and adds TEST-473. Verified locally with YAML parsing, Ruff format/check, focused pytest, mypy, strict MkDocs, SpecSmith validate, and audit.