### PR TITLE
fix(ci): verify RTD project source

### DIFF
--- a/.github/workflows/rtd-deploy.yml
+++ b/.github/workflows/rtd-deploy.yml
@@ -56,11 +56,23 @@ jobs:
           PROJECT_STATUS=$(curl -sS -o /tmp/rtd-project.json -w "%{http_code}" -X PATCH \
             -H "Authorization: Token $RTD_TOKEN" \
             -H "Content-Type: application/json" \
-            -d '{"repository":{"url":"https://github.com/layer1labs/specsmith.git","type":"git"},"default_branch":"main","homepage":"https://github.com/layer1labs/specsmith"}' \
+            -d '{"repository":{"url":"https://github.com/layer1labs/specsmith","type":"git"},"default_branch":"main","homepage":"https://github.com/layer1labs/specsmith"}' \
             "https://readthedocs.org/api/v3/projects/specsmith/")
           echo "RTD project update: HTTP $PROJECT_STATUS"
           cat /tmp/rtd-project.json
           [ "$PROJECT_STATUS" = "204" ] || { echo "::error::RTD project update failed."; exit 1; }
+
+          PROJECT_STATE_STATUS=$(curl -sS -o /tmp/rtd-project-state.json -w "%{http_code}" \
+            -H "Authorization: Token $RTD_TOKEN" \
+            "https://readthedocs.org/api/v3/projects/specsmith/")
+          [ "$PROJECT_STATE_STATUS" = "200" ] || { echo "::error::RTD project verification failed with HTTP $PROJECT_STATE_STATUS."; cat /tmp/rtd-project-state.json; exit 1; }
+          PROJECT_REPOSITORY=$(python -c "import json; print(json.load(open('/tmp/rtd-project-state.json'))['repository']['url'])")
+          PROJECT_BRANCH=$(python -c "import json; print(json.load(open('/tmp/rtd-project-state.json'))['default_branch'])")
+          case "$PROJECT_REPOSITORY" in
+            https://github.com/layer1labs/specsmith|https://github.com/layer1labs/specsmith.git) ;;
+            *) echo "::error::RTD project repository is '$PROJECT_REPOSITORY', not layer1labs/specsmith."; exit 1 ;;
+          esac
+          [ "$PROJECT_BRANCH" = "main" ] || { echo "::error::RTD project default branch is '$PROJECT_BRANCH', not main."; exit 1; }
 
           SYNC_STATUS=$(curl -sS -o /tmp/rtd-sync.json -w "%{http_code}" -X POST \
             -H "Authorization: Token $RTD_TOKEN" \

--- a/tests/test_rtd_deploy_workflow.py
+++ b/tests/test_rtd_deploy_workflow.py
@@ -9,8 +9,11 @@ def test_rtd_deploy_uses_canonical_project_and_main() -> None:
         Path(__file__).resolve().parents[1] / ".github" / "workflows" / "rtd-deploy.yml"
     ).read_text(encoding="utf-8")
 
-    assert "https://github.com/layer1labs/specsmith.git" in workflow
+    assert "https://github.com/layer1labs/specsmith" in workflow
     assert '"default_branch":"main"' in workflow
+    assert "rtd-project-state.json" in workflow
+    assert "PROJECT_REPOSITORY" in workflow
+    assert "PROJECT_BRANCH" in workflow
     assert "projects/specsmith/sync-versions/" in workflow
     assert '[ "$PROJECT_STATUS" = "204" ]' in workflow
     assert '[ "$SYNC_STATUS" = "202" ]' in workflow


### PR DESCRIPTION
Completes the RTD latest remediation by normalizing the project repository URL and verifying the RTD API reports layer1labs/specsmith plus main before version sync/builds proceed. Adds regression assertions for the remote-state check. Focused pytest, Ruff, YAML parsing, and SpecSmith audit are green locally.