### PR TITLE
fix(release): invoke pytest with repository import path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       # packages that mypy can still use (like yaml) even without stub files.
       - run: pip install types-pyyaml
       - run: mypy src/specsmith --ignore-missing-imports --disable-error-code import-untyped
-      - run: pytest tests/ -x -q
+      - run: python -m pytest tests/ -x -q
 
   code-scan-gate:
     # Block the release if any High or Critical code scanning alerts are open.

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -28,6 +28,8 @@ def test_prepare_workflow_defaults_to_check_and_protects_refs() -> None:
 
 def test_tag_workflow_is_non_mutating_and_rejects_duplicates() -> None:
     text = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    assert "python -m pytest tests/ -x -q" in text
+    assert "- run: pytest tests/ -x -q" not in text
     assert "release_bootstrap.py check" in text
     assert "merge-base --is-ancestor" in text
     assert "build --sdist" in text


### PR DESCRIPTION
Fixes the unpublished v0.23.0 release gate failure by invoking pytest as a Python module, which keeps the repository root on sys.path for tests importing scripts.release_evidence. Adds a regression assertion for the tag workflow. Local verification: ruff, format check, mypy, strict governance validation, sync check, audit (144 checks), and the full corrected release test command: 2421 passed, 9 skipped, 5 xfailed.