### PR TITLE
release: v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ consolidated into the next published release.
 
 ## [Unreleased]
 
-## [0.23.0] - 2026-07-18
+## [0.23.1] - 2026-07-18
 
 ### Added
 - Guided context compression and predictive context-risk controls with governed
@@ -36,6 +36,8 @@ consolidated into the next published release.
   compilation.
 
 ### Fixed
+- Release test collection now invokes pytest as a Python module so repository-
+  private release-evidence helpers import reliably in the tag workflow.
 - Case-insensitive MCP project-path deduplication, transient Windows file-handle
   retries, test isolation, and atomic repair of old or tampered registry entries.
 - Provider failures that previously allowed partial GovernanceBench artifacts to
@@ -1006,8 +1008,8 @@ See git history for per-commit details on intermediate versions.
 
 ---
 
-[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.23.0...HEAD
-[0.23.0]: https://github.com/layer1labs/specsmith/compare/v0.22.5...v0.23.0
+[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.23.1...HEAD
+[0.23.1]: https://github.com/layer1labs/specsmith/compare/v0.22.5...v0.23.1
 [0.22.5]: https://github.com/layer1labs/specsmith/compare/v0.22.4...v0.22.5
 [0.22.4]: https://github.com/layer1labs/specsmith/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/layer1labs/specsmith/compare/v0.22.2...v0.22.3

--- a/docs/SPECSMITH.yml
+++ b/docs/SPECSMITH.yml
@@ -9,10 +9,10 @@ description: |
   through governance, traceability, and automated compliance checking.
 
 type: python
-version: 0.23.0
+version: 0.23.1
 # Governance schema/tool version that last generated or migrated this project.
 # This is intentionally distinct from the package/project release version above.
-spec_version: 0.23.0
+spec_version: 0.23.1
 license: MIT
 author: Layer1 Labs
 url: https://github.com/layer1labs/specsmith

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specsmith"
-version = "0.23.0"
+version = "0.23.1"
 description = "AEE governance toolkit for AI-assisted development — session preflight gates, multi-agent dispatch, requirements↔test traceability, ESDB persistence, MCP server, and skills for Warp, Cursor, Claude Code, Copilot, Windsurf, Aider, and Zoo Code."
 readme = "README.md"
 license = "MIT"

--- a/src/specsmith/__init__.py
+++ b/src/specsmith/__init__.py
@@ -8,8 +8,8 @@ from importlib.metadata import version as _pkg_version
 try:
     __version__: str = _pkg_version("specsmith")
 except PackageNotFoundError:  # running from source without install
-    __version__ = "0.23.0"  # fallback: keep in sync with pyproject.toml
+    __version__ = "0.23.1"  # fallback: keep in sync with pyproject.toml
 
 # Governance/schema version — independent from the package version.
 # Bump this when the scaffold config schema or governance rules change.
-GOVERNANCE_VERSION: str = "0.23.0"
+GOVERNANCE_VERSION: str = "0.23.1"


### PR DESCRIPTION
Immutable recovery release for the unpublished v0.23.0 tag. Consolidates the unreleased 0.23.0 changelog into v0.23.1, records the corrected module-style pytest release gate, and updates package/project/governance metadata consistently. Trusted Prepare Release run 29665318150 passed candidate build/install, constrained synchronization, and clean second pass. Focused release contracts: 23 passed; governance audit: 145 checks; main hotfix CI and both analyzers are green with zero open code-scanning alerts.