### PR TITLE
fix(release): install stable validator dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install build
+      - run: python -m pip install build pyyaml
       - name: Verify stable release version and tag
         run: PYTHONPATH=src python scripts/check_stable_release.py --expected-version "${{ github.ref_name }}"
       - name: Verify tag belongs to main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ consolidated into the next published release.
 
 ## [Unreleased]
 
-## [0.23.1] - 2026-07-18
+## [0.23.2] - 2026-07-18
 
 ### Added
 - Guided context compression and predictive context-risk controls with governed
@@ -36,6 +36,8 @@ consolidated into the next published release.
   compilation.
 
 ### Fixed
+- Release build environments now install PyYAML before validating the stable
+  package version and tag, preventing pre-publication dependency failures.
 - Release test collection now invokes pytest as a Python module so repository-
   private release-evidence helpers import reliably in the tag workflow.
 - Case-insensitive MCP project-path deduplication, transient Windows file-handle
@@ -1008,8 +1010,8 @@ See git history for per-commit details on intermediate versions.
 
 ---
 
-[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.23.1...HEAD
-[0.23.1]: https://github.com/layer1labs/specsmith/compare/v0.22.5...v0.23.1
+[Unreleased]: https://github.com/layer1labs/specsmith/compare/v0.23.2...HEAD
+[0.23.2]: https://github.com/layer1labs/specsmith/compare/v0.22.5...v0.23.2
 [0.22.5]: https://github.com/layer1labs/specsmith/compare/v0.22.4...v0.22.5
 [0.22.4]: https://github.com/layer1labs/specsmith/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/layer1labs/specsmith/compare/v0.22.2...v0.22.3

--- a/docs/SPECSMITH.yml
+++ b/docs/SPECSMITH.yml
@@ -9,10 +9,10 @@ description: |
   through governance, traceability, and automated compliance checking.
 
 type: python
-version: 0.23.1
+version: 0.23.2
 # Governance schema/tool version that last generated or migrated this project.
 # This is intentionally distinct from the package/project release version above.
-spec_version: 0.23.1
+spec_version: 0.23.2
 license: MIT
 author: Layer1 Labs
 url: https://github.com/layer1labs/specsmith

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specsmith"
-version = "0.23.1"
+version = "0.23.2"
 description = "AEE governance toolkit for AI-assisted development — session preflight gates, multi-agent dispatch, requirements↔test traceability, ESDB persistence, MCP server, and skills for Warp, Cursor, Claude Code, Copilot, Windsurf, Aider, and Zoo Code."
 readme = "README.md"
 license = "MIT"

--- a/src/specsmith/__init__.py
+++ b/src/specsmith/__init__.py
@@ -8,8 +8,8 @@ from importlib.metadata import version as _pkg_version
 try:
     __version__: str = _pkg_version("specsmith")
 except PackageNotFoundError:  # running from source without install
-    __version__ = "0.23.1"  # fallback: keep in sync with pyproject.toml
+    __version__ = "0.23.2"  # fallback: keep in sync with pyproject.toml
 
 # Governance/schema version — independent from the package version.
 # Bump this when the scaffold config schema or governance rules change.
-GOVERNANCE_VERSION: str = "0.23.1"
+GOVERNANCE_VERSION: str = "0.23.2"

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -28,6 +28,7 @@ def test_prepare_workflow_defaults_to_check_and_protects_refs() -> None:
 
 def test_tag_workflow_is_non_mutating_and_rejects_duplicates() -> None:
     text = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    assert "python -m pip install build pyyaml" in text
     assert "python -m pytest tests/ -x -q" in text
     assert "- run: pytest tests/ -x -q" not in text
     assert "release_bootstrap.py check" in text


### PR DESCRIPTION
## Summary
- install PyYAML in the release build job before stable-version validation
- add workflow regression coverage
- advance the unpublished immutable recovery candidate to v0.23.2

## Verification
- 31 focused release tests passed
- stable release validator accepted 0.23.2
- Ruff check/format passed
- Specsmith audit healthy (147 checks)

The v0.23.1 tag failed before build/publication and remains immutable; this PR prepares the next version.