### PR TITLE
fix(release): extend PyPI propagation window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ consolidated into the next published release.
 
 ## [Unreleased]
 
+### Changed
+- PyPI post-publication verification now allows a bounded three-minute
+  propagation window before failing.
+
 ## [0.23.3] - 2026-07-18
 
 ### Fixed

--- a/scripts/verify_publication.py
+++ b/scripts/verify_publication.py
@@ -17,6 +17,10 @@ except ModuleNotFoundError:  # Direct execution adds scripts/, not the repositor
     from release_evidence import create_receipt
 
 
+PYPI_PROPAGATION_ATTEMPTS = 19
+PYPI_PROPAGATION_DELAY_SECONDS = 10
+
+
 def sha256_file(path: Path) -> str:
     hasher = hashlib.sha256()
     with path.open("rb") as stream:
@@ -44,7 +48,10 @@ def verify_pypi_files(dist_dir: Path, payload: dict[str, Any]) -> list[dict[str,
 
 
 def fetch_pypi_payload(
-    version: str, *, attempts: int = 6, delay_seconds: float = 10
+    version: str,
+    *,
+    attempts: int = PYPI_PROPAGATION_ATTEMPTS,
+    delay_seconds: float = PYPI_PROPAGATION_DELAY_SECONDS,
 ) -> dict[str, Any]:
     """Fetch a release after allowing bounded time for PyPI propagation."""
     if attempts < 1:

--- a/tests/test_release_evidence.py
+++ b/tests/test_release_evidence.py
@@ -7,7 +7,12 @@ from urllib.error import HTTPError
 import pytest
 
 from scripts.release_evidence import create_receipt, create_seal, digest
-from scripts.verify_publication import fetch_pypi_payload, verify_pypi_files
+from scripts.verify_publication import (
+    PYPI_PROPAGATION_ATTEMPTS,
+    PYPI_PROPAGATION_DELAY_SECONDS,
+    fetch_pypi_payload,
+    verify_pypi_files,
+)
 
 
 def test_receipt_links_immutable_seal() -> None:
@@ -63,3 +68,7 @@ def test_pypi_fetch_retries_release_propagation(monkeypatch: pytest.MonkeyPatch)
 
     assert payload["info"]["version"] == "1.2.3"
     assert sleeps == [0]
+
+
+def test_pypi_default_propagation_window_is_at_least_three_minutes() -> None:
+    assert (PYPI_PROPAGATION_ATTEMPTS - 1) * PYPI_PROPAGATION_DELAY_SECONDS >= 180


### PR DESCRIPTION
## Summary
- extend bounded PyPI propagation tolerance from 50 seconds to three minutes
- expose named retry constants and lock the minimum window in tests
- document the post-v0.23.3 hardening under Unreleased

## Verification
- 5 receipt tests passed
- Ruff check/format passed
- Specsmith audit healthy (149 checks)
- v0.23.3 release attempt 2 completed fully green with receipt attached