### PR TITLE
chore(governance): record session kill switch

### DIFF
--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -363,3 +363,11 @@
 - **REQs affected**: TEST-308
 - **Status**: complete
 - **Chain hash**: `45a2b628796cf38d...`
+
+## 2026-07-18T21:13 — KILL SWITCH ACTIVATED: emergency stop
+- **Author**: specsmith-operator
+- **Type**: kill-switch
+- **REQs affected**: REG-005
+- **Status**: complete
+- **Epistemic status**: high
+- **Chain hash**: `de92f088e4d88fa5...`


### PR DESCRIPTION
Records the mandated Specsmith session-end kill-switch audit event in docs/LEDGER.md. No runtime, release, documentation-content, or package behavior changes.