### PR TITLE
chore(governance): record release branch cleanup

### DIFF
--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -371,3 +371,11 @@
 - **Status**: complete
 - **Epistemic status**: high
 - **Chain hash**: `de92f088e4d88fa5...`
+
+## 2026-07-18T21:39 — KILL SWITCH ACTIVATED: emergency stop
+- **Author**: specsmith-operator
+- **Type**: kill-switch
+- **REQs affected**: REG-005
+- **Status**: complete
+- **Epistemic status**: high
+- **Chain hash**: `a25b7b6f3dade264...`


### PR DESCRIPTION
Records the mandatory Specsmith kill-switch ledger event generated at session start before deleting the three fully merged local release branches. No product code, release tags, or configuration changed. Branch deletion itself affects Git refs only and origin already had no release heads.