### PR TITLE
fix(docs): correct public Read the Docs routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ consolidated into the next published release.
 
 ## [Unreleased]
 
+### Fixed
+- Public documentation links now use Read the Docs' active translation-free
+  `/stable/` and `/latest/` routes instead of obsolete `/en/` routes.
+
 ## [0.24.0] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/layer1labs/specsmith/actions/workflows/ci.yml/badge.svg)](https://github.com/layer1labs/specsmith/actions/workflows/ci.yml)
 [![Sponsor](https://img.shields.io/badge/sponsor-%E2%9D%A4-ea4aaa?logo=github)](https://github.com/sponsors/layer1labs)
-[![Docs](https://readthedocs.org/projects/specsmith/badge/?version=stable)](https://specsmith.readthedocs.io/en/stable/)
+[![Docs](https://readthedocs.org/projects/specsmith/badge/?version=stable)](https://specsmith.readthedocs.io/stable/)
 [![PyPI](https://img.shields.io/pypi/v/specsmith?label=stable&style=flat&color=blue&cacheSeconds=60)](https://pypi.org/project/specsmith/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/layer1labs/specsmith/blob/main/LICENSE)
@@ -10,7 +10,7 @@
 SpecSmith is the governance layer for AI-assisted development: it sits between agents and your repo, enforces preflight decisions, and records requirement/test traceability with auditable evidence. It is **not** an IDE, autonomous coding agent, CI runner, or legal-compliance certifier. Use SpecSmith when changes need repeatable controls, work-item lineage, and review-ready artifacts; do not use it for throwaway prototyping where governance overhead is unnecessary. Compared with GitHub Spec Kit, OpenSpec, and BMAD, SpecSmith adds execution-time policy gates and trace chains. Compared with Aider, Claude Code, and Cursor, SpecSmith governs those clients instead of replacing them. Compared with LangGraph and AutoGen, SpecSmith prioritizes software-governance outcomes and evidence quality over general-purpose multi-agent orchestration.
 
 For Zoo Code / Roo Code, use the canonical
-[setup, repair, and governed-context guide](https://specsmith.readthedocs.io/en/stable/zoo-code-roo/).
+[setup, repair, and governed-context guide](https://specsmith.readthedocs.io/stable/zoo-code-roo/).
 
 ## Architecture at a glance
 
@@ -41,7 +41,7 @@ AI Agents / IDE Clients
 
 ### Governance efficiency benchmark
 
-The latest completed [multi-condition benchmark](https://specsmith.readthedocs.io/en/stable/efficiency-benchmark/)
+The latest completed [multi-condition benchmark](https://specsmith.readthedocs.io/stable/efficiency-benchmark/)
 was a historical 13-condition run across seven coding and safety tasks.
 GPT-4o-mini completed all 182 cells; the Qwen run was interrupted by
 provider credit and rate-limit errors and is excluded from model comparisons.
@@ -70,8 +70,8 @@ data so unavailable cells cannot appear as 0%-pass/$0-cost model results.
 - **12 focused Specsmith skills**; generic capabilities stay with the host agent
 - **Development mode** with improvement tracking and session analysis
 
-See the [full benchmark report](https://specsmith.readthedocs.io/en/stable/efficiency-benchmark/)
-and [comparison validity report](https://specsmith.readthedocs.io/en/stable/model-comparison/).
+See the [full benchmark report](https://specsmith.readthedocs.io/stable/efficiency-benchmark/)
+and [comparison validity report](https://specsmith.readthedocs.io/stable/model-comparison/).
 
 ### Development Mode Features
 
@@ -85,8 +85,8 @@ When enabled in project configuration, development mode provides:
 
 To enable development mode, set `enable_development_mode: true` in your project's `.specsmith/config.yml` file.
 
-See the [full benchmark report](https://specsmith.readthedocs.io/en/stable/efficiency-benchmark/)
-and [comparison validity report](https://specsmith.readthedocs.io/en/stable/model-comparison/).
+See the [full benchmark report](https://specsmith.readthedocs.io/stable/efficiency-benchmark/)
+and [comparison validity report](https://specsmith.readthedocs.io/stable/model-comparison/).
 
 **v0.23.0** — Guided context compression, resilient SpecSmith/Zoo-Code config
 repair, replicated ESDB evidence, cross-platform release closure, and
@@ -273,9 +273,9 @@ specsmith esdb status
 ```
 
 To obtain a chronomemory ESDB license:
-[licensing@layer1labs.ai](mailto:licensing@layer1labs.ai) · [ESDB licensing docs](https://specsmith.readthedocs.io/en/stable/esdb/#licensing)
+[licensing@layer1labs.ai](mailto:licensing@layer1labs.ai) · [ESDB licensing docs](https://specsmith.readthedocs.io/stable/esdb/#licensing)
 · [ChronoMemory commercial terms](https://github.com/layer1labs/specsmith/blob/develop/COMMERCIAL-LICENSE.md)
-See the [full ESDB docs](https://specsmith.readthedocs.io/en/stable/esdb/) for a feature comparison and Python API reference.
+See the [full ESDB docs](https://specsmith.readthedocs.io/stable/esdb/) for a feature comparison and Python API reference.
 
 **Upgrading specsmith:**
 
@@ -325,7 +325,7 @@ token path. If you already use an AI coding tool, the native integration is pref
 Specsmith supplies requirements, linked tests, uncertainty, and evidence while the
 host retains its own Git, test, browser, and framework tools.
 
-See the [five-minute quick start](https://specsmith.readthedocs.io/en/stable/quickstart/)
+See the [five-minute quick start](https://specsmith.readthedocs.io/stable/quickstart/)
 for provider setup, Zoo/Roo repair, first-run errors, and the integration matrix.
 
 ### Standalone CLI (no AI agent)
@@ -340,7 +340,7 @@ specsmith save                      # ESDB backup + commit + push
 specsmith kill-session              # clean shutdown
 ```
 
-For Grace, headless use, and CI: **[Standalone CLI docs →](https://specsmith.readthedocs.io/en/stable/standalone-cli/)**
+For Grace, headless use, and CI: **[Standalone CLI docs →](https://specsmith.readthedocs.io/stable/standalone-cli/)**
 
 ---
 
@@ -691,7 +691,7 @@ specsmith wi import --from-ledger
 behaviour not covered by any existing REQ and the pattern is expected to recur.
 Close (`wi close`) for bug fixes, refactors, and chores that already have a matching REQ.
 
-Full documentation: [`docs/site/wi-lifecycle.md`](https://specsmith.readthedocs.io/en/stable/wi-lifecycle/)
+Full documentation: [`docs/site/wi-lifecycle.md`](https://specsmith.readthedocs.io/stable/wi-lifecycle/)
 
 ---
 
@@ -1198,7 +1198,7 @@ specsmith integrate copilot   # writes .github/copilot-instructions.md
 
 Copilot reads `.github/copilot-instructions.md` for all workspace interactions. MCP not yet natively supported; governance is enforced through the instructions file and `AGENTS.md`.
 
-Full per-tool setup: **[Agent Integrations docs →](https://specsmith.readthedocs.io/en/stable/agent-integrations/)**
+Full per-tool setup: **[Agent Integrations docs →](https://specsmith.readthedocs.io/stable/agent-integrations/)**
 
 ---
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -80,7 +80,7 @@ specsmith esdb status
 ```
 
 Obtain a license: [licensing@layer1labs.ai](mailto:licensing@layer1labs.ai) ·
-[ESDB licensing docs](https://specsmith.readthedocs.io/en/stable/esdb/#licensing)
+[ESDB licensing docs](https://specsmith.readthedocs.io/stable/esdb/#licensing)
 
 Full backend comparison, Python API, and CLI reference: [ESDB docs](esdb.md)
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -89,8 +89,8 @@ When you run `specsmith init` or `specsmith import`, your project gets:
 - **Hooks** — H13 enforcement, ledger hints, context budget alerts
 
 !!! note "Documentation Versions"
-    **Stable:** [specsmith.readthedocs.io/en/stable/](https://specsmith.readthedocs.io/en/stable/) — matches `pip install specsmith`
-    **Dev (latest):** [specsmith.readthedocs.io/en/latest/](https://specsmith.readthedocs.io/en/latest/) — matches `pip install --pre specsmith`
+    **Stable:** [specsmith.readthedocs.io/stable/](https://specsmith.readthedocs.io/stable/) — matches `pip install specsmith`
+    **Dev (latest):** [specsmith.readthedocs.io/latest/](https://specsmith.readthedocs.io/latest/) — matches `pip install --pre specsmith`
 
 ## The AEE Workflow — 7 Phases
 

--- a/src/specsmith/migrations/m003_compliance_init.py
+++ b/src/specsmith/migrations/m003_compliance_init.py
@@ -39,7 +39,7 @@ Each file overrides the built-in regulation status for this project:
   # Store results to ESDB audit trail
   specsmith compliance audit
 
-See: https://specsmith.readthedocs.io/en/stable/compliance/
+See: https://specsmith.readthedocs.io/stable/compliance/
 """
 
 _EU_OVERLAY = """\

--- a/src/specsmith/templates/governance/epistemic-axioms.md.j2
+++ b/src/specsmith/templates/governance/epistemic-axioms.md.j2
@@ -4,7 +4,7 @@ This document defines the five Applied Epistemic Engineering (AEE) axioms as the
 to {{ project.name }}. These axioms govern how beliefs (requirements, decisions, hypotheses)
 are framed, challenged, and reconstructed in this project.
 
-See the AEE primer: https://specsmith.readthedocs.io/en/stable/aee-primer/
+See the AEE primer: https://specsmith.readthedocs.io/stable/aee-primer/
 
 ---
 

--- a/tests/test_docs_artifacts.py
+++ b/tests/test_docs_artifacts.py
@@ -17,3 +17,20 @@ def test_mkdocs_site_output_is_ignored_for_projects_and_scaffolds() -> None:
 
     assert "/site/" in project_lines
     assert "/site/" in template_lines
+
+
+def test_public_rtd_links_use_translation_free_routes() -> None:
+    """Published links must match the project's active RTD versioning scheme."""
+    root = Path(__file__).parents[1]
+    candidates = [root / "README.md"]
+    candidates.extend((root / "docs" / "site").rglob("*.md"))
+    candidates.extend((root / "src" / "specsmith").rglob("*.py"))
+    candidates.extend((root / "src" / "specsmith").rglob("*.j2"))
+
+    obsolete = "specsmith.readthedocs.io/en/"
+    offenders = [
+        str(path.relative_to(root))
+        for path in candidates
+        if obsolete in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == []


### PR DESCRIPTION
## Summary
- replace obsolete /en/stable and /en/latest RTD links with the active translation-free routes
- correct README, docs, template, and migration guidance
- add regression coverage preventing obsolete public routes

## Verification
- pytest tests/test_docs_artifacts.py tests/test_invocation_docs.py -q (3 passed)
- uff format --check and uff check on changed Python files
- mkdocs build --strict`n- live /stable/, /stable/quickstart/, and /latest/quickstart/ return HTTP 200 and contain Grace