### PR TITLE
fix: scope preflight identity by project

### DIFF
--- a/.specsmith/requirements.json
+++ b/.specsmith/requirements.json
@@ -4894,5 +4894,16 @@
     "test_ids": [
       "TEST-511"
     ]
+  },
+  {
+    "id": "REQ-486",
+    "version": 1,
+    "title": "Project-scoped mutation preflight identity",
+    "description": "Preflight MUST classify explicit imperative repository mutation requests as change, refactor, release, or destructive intent and MUST NOT silently accept them as read-only asks. Informational questions remain read-only. Work-item identifiers MUST be deterministic and idempotent within one canonical project root while remaining distinct for the same utterance in different repositories.",
+    "source": "GitHub issue",
+    "status": "implemented",
+    "test_ids": [
+      "TEST-512"
+    ]
   }
 ]

--- a/.specsmith/testcases.json
+++ b/.specsmith/testcases.json
@@ -5590,5 +5590,17 @@
     "input": {},
     "expected_behavior": "Core AEE controls remain effective while token-amplifying ceremony and generic skills are absent",
     "confidence": 1.0
+  },
+  {
+    "id": "TEST-512",
+    "version": 1,
+    "title": "Mutation intent and project-scoped work-item identity",
+    "description": "Exact issue #357 language and common imperative edit requests enter governed mutation handling, informational removal questions remain read-only, and identical accepted utterances are idempotent within one repository but produce distinct work-item IDs across canonical project roots.",
+    "requirement_id": "REQ-486",
+    "type": "unit",
+    "verification_method": "pytest tests/test_broker_scope.py tests/test_wi_lifecycle.py::TestPreflightWiring::test_work_item_ids_are_idempotent_per_project_and_distinct_across_projects",
+    "input": {},
+    "expected_behavior": "Explicit edits cannot bypass governance and work-item evidence cannot collide across projects",
+    "confidence": 1.0
   }
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ consolidated into the next published release.
 ### Fixed
 - Public documentation links now use Read the Docs' active translation-free
   `/stable/` and `/latest/` routes instead of obsolete `/en/` routes.
+- Preflight now recognizes direct mutation requests instead of accepting them
+  as read-only, and deterministic work-item IDs are scoped to the canonical
+  project root to prevent cross-repository collisions (#357).
 
 ## [0.24.0] - 2026-07-20
 

--- a/docs/LEDGER.md
+++ b/docs/LEDGER.md
@@ -400,3 +400,15 @@
 - **Type**: wi_close
 - **Status**: complete
 - **Chain hash**: `58082c054b385ac6...`
+
+## 2026-07-20T12:30 — wi_archive WI-C75FAEE12E60: Clarification preflight superseded by exact issue #357 behavior WI-1D0C052BED88
+- **Author**: specsmith
+- **Type**: wi_archive
+- **Status**: complete
+- **Chain hash**: `40158f57492320ba...`
+
+## 2026-07-20T12:30 — wi_close WI-1D0C052BED88: Issue #357 implementation verified by 2273-test full suite
+- **Author**: specsmith
+- **Type**: wi_close
+- **Status**: complete
+- **Chain hash**: `fd57d284e58c9b13...`

--- a/docs/requirements/govern_bench.yml
+++ b/docs/requirements/govern_bench.yml
@@ -48,3 +48,13 @@
     MCP, or adapter formats and exchange the smallest sufficient AEE contract.
   source: GovernanceBench token-efficiency corrective design
   status: implemented
+- id: REQ-486
+  title: Project-scoped mutation preflight identity
+  description: >-
+    Preflight MUST classify explicit imperative repository mutation requests as
+    change, refactor, release, or destructive intent and MUST NOT silently accept
+    them as read-only asks. Informational questions remain read-only. Work-item
+    identifiers MUST be deterministic and idempotent within one canonical project
+    root while remaining distinct for the same utterance in different repositories.
+  source: GitHub issue #357
+  status: implemented

--- a/docs/tests/govern_bench.yml
+++ b/docs/tests/govern_bench.yml
@@ -32,3 +32,16 @@
   input: {}
   expected_behavior: Core AEE controls remain effective while token-amplifying ceremony and generic skills are absent
   confidence: 1.0
+- id: TEST-512
+  title: Mutation intent and project-scoped work-item identity
+  description: >-
+    Exact issue #357 language and common imperative edit requests enter governed
+    mutation handling, informational removal questions remain read-only, and
+    identical accepted utterances are idempotent within one repository but produce
+    distinct work-item IDs across canonical project roots.
+  requirement_id: REQ-486
+  type: unit
+  verification_method: pytest tests/test_broker_scope.py tests/test_wi_lifecycle.py::TestPreflightWiring::test_work_item_ids_are_idempotent_per_project_and_distinct_across_projects
+  input: {}
+  expected_behavior: Explicit edits cannot bypass governance and work-item evidence cannot collide across projects
+  confidence: 1.0

--- a/src/specsmith/agent/broker.py
+++ b/src/specsmith/agent/broker.py
@@ -120,6 +120,19 @@ _CHANGE_PATTERNS = (
     re.compile(r"\b(rename)\b", re.IGNORECASE),
     re.compile(r"\b(update|migrate|upgrade|edit)\b", re.IGNORECASE),
     re.compile(r"\b(remove|delete)\s+(the\s+)?(unused|stale|legacy)\b", re.IGNORECASE),
+    # Explicit mutation requests must never fall through to READ_ONLY_ASK.
+    # Anchor the bare verbs so informational questions such as "how do I
+    # remove X?" remain read-only while direct imperatives are governed.
+    re.compile(
+        r"^\s*(?:(?:please|kindly)\s+)?"
+        r"(remove|enforce|preserve|modify|change|replace|disable|enable|configure)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*(?:can|could|would|will)\s+you\s+"
+        r"(remove|enforce|preserve|modify|change|replace|disable|enable|configure)\b",
+        re.IGNORECASE,
+    ),
 )
 
 _READ_ONLY_PATTERNS = (

--- a/src/specsmith/governance_logic.py
+++ b/src/specsmith/governance_logic.py
@@ -310,9 +310,13 @@ def run_preflight(
         decision_str == "needs_clarification" and intent in (Intent.RELEASE, Intent.DESTRUCTIVE)
     )
     if _alloc_wi and not predict_only:
-        # Deterministic work-item ID: hash(utterance + intent + requirement_ids)
-        # so the same preflight call always produces the same WI idempotently.
-        _seed = f"{utterance}|{intent.value}|{','.join(sorted(requirement_ids))}"
+        # Deterministic and project-scoped: the same preflight remains
+        # idempotent inside one repository without colliding across independent
+        # repositories that happen to use the same utterance.
+        _project_identity = os.path.normcase(_safe_root)
+        _seed = (
+            f"{_project_identity}|{utterance}|{intent.value}|{','.join(sorted(requirement_ids))}"
+        )
         work_item_id = f"WI-{hashlib.sha256(_seed.encode('utf-8')).hexdigest()[:12].upper()}"
     else:
         work_item_id = ""

--- a/tests/test_broker_scope.py
+++ b/tests/test_broker_scope.py
@@ -6,6 +6,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+
+@pytest.mark.parametrize(
+    "utterance",
+    [
+        (
+            "Remove Dependabot configuration and enforce the approved main-only "
+            "GitHub branch model while preserving full commit-pinned private CI actions."
+        ),
+        "Please configure repository branch protection",
+        "Could you replace the stale workflow?",
+    ],
+)
+def test_explicit_mutation_requests_are_not_read_only(utterance: str) -> None:
+    """Regression for #357: imperative edits must enter governance."""
+    from specsmith.agent.broker import Intent, classify_intent
+
+    assert classify_intent(utterance) in {Intent.CHANGE, Intent.DESTRUCTIVE}
+
+
+def test_informational_removal_question_remains_read_only() -> None:
+    from specsmith.agent.broker import Intent, classify_intent
+
+    assert classify_intent("How do I remove a stale workflow?") == Intent.READ_ONLY_ASK
+
 
 def _write_requirements(path: Path) -> None:
     path.write_text(

--- a/tests/test_wi_lifecycle.py
+++ b/tests/test_wi_lifecycle.py
@@ -795,6 +795,26 @@ def _seed_requirements(tmp_path: Path, content: str = "") -> None:
 
 
 class TestPreflightWiring:
+    def test_work_item_ids_are_idempotent_per_project_and_distinct_across_projects(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Regression for #357: identical intents cannot collide across repositories."""
+        from specsmith.governance_logic import run_preflight
+
+        project_a = tmp_path / "project-a"
+        project_b = tmp_path / "project-b"
+        project_a.mkdir()
+        project_b.mkdir()
+        utterance = "what does the retry module do?"
+
+        first = run_preflight(utterance, project_dir=str(project_a))
+        repeated = run_preflight(utterance, project_dir=str(project_a))
+        other_project = run_preflight(utterance, project_dir=str(project_b))
+
+        assert first["work_item_id"] == repeated["work_item_id"]
+        assert first["work_item_id"] != other_project["work_item_id"]
+
     def test_accepted_preflight_creates_wi(self, tmp_path: Path) -> None:
         """read-only asks are always accepted regardless of project state."""
         from specsmith.governance_logic import run_preflight


### PR DESCRIPTION
## Summary
- classify direct imperative mutation requests as governed changes
- preserve read-only classification for informational questions
- scope deterministic work-item IDs to the canonical project root
- add REQ-486 / TEST-512 and regression coverage

## Verification
- 2,273 passed, 9 skipped, 5 xfailed
- Ruff format/check, mypy, MkDocs strict, governance audit, and diff checks pass

Fixes #357